### PR TITLE
Sync all AI IDE docs & genericize game references

### DIFF
--- a/.kiro/hooks/research-and-spec-before-task.json
+++ b/.kiro/hooks/research-and-spec-before-task.json
@@ -1,0 +1,12 @@
+{
+  "name": "Research & Spec Before Task",
+  "version": "1.0.0",
+  "description": "Before any spec task starts: research the specific game or API online, then create a spec file with a proper plan before touching any code.",
+  "when": {
+    "type": "preTaskExecution"
+  },
+  "then": {
+    "type": "askAgent",
+    "prompt": "A spec task is about to start. Before writing any code, do the following:\n\n1. RESEARCH: Search the web for documentation, known issues, and community findings specific to the game or API involved in this task. For example: if fixing input for Re-Volt, search for 'Re-Volt DirectInput raw input handling', 'Re-Volt Xbox PC input method', etc. Summarise what you find — input method used (DirectInput/RawInput/WinAPI), known quirks, relevant community fixes.\n\n2. SPEC: Create or update a spec file at `.kiro/specs/<task-name>.md` with:\n   - Problem statement (what is broken and why)\n   - Research findings (what the game/API actually does)\n   - Proposed fix approach (the correct layer to fix it)\n   - Implementation steps (ordered, specific)\n   - Verification method (how to confirm it works)\n\n3. Only proceed to implementation after the spec is written."
+  }
+}

--- a/.kiro/hooks/update-docs-after-task.json
+++ b/.kiro/hooks/update-docs-after-task.json
@@ -1,0 +1,12 @@
+{
+  "name": "Update Docs After Task",
+  "version": "1.0.0",
+  "description": "After each spec task completes: update tool-catalog.md and any relevant steering files to reflect what was implemented.",
+  "when": {
+    "type": "postTaskExecution"
+  },
+  "then": {
+    "type": "askAgent",
+    "prompt": "A spec task just completed. Update documentation:\n\n1. Update `.kiro/steering/tool-catalog.md` — add, change, or remove any tool entries that reflect what was implemented in this task. If a command's behaviour changed, the catalog entry must change too.\n\n2. If the task involved the FFP porting workflow, update `.kiro/steering/dx9-ffp-port.md` with any new findings (register layouts, pitfalls, game-specific notes).\n\n3. If the task introduced a new game-specific macro file or patches folder, note the pattern in the relevant steering file."
+  }
+}

--- a/.kiro/hooks/verify-and-update-docs.json
+++ b/.kiro/hooks/verify-and-update-docs.json
@@ -1,0 +1,12 @@
+{
+  "name": "Verify Fix & Update Docs",
+  "version": "1.0.0",
+  "description": "After agent stops: verify the fix actually works with a real test, then update docs — game kb.h for game-specific findings, tool-catalog.md only if a reusable tool changed.",
+  "when": {
+    "type": "agentStop"
+  },
+  "then": {
+    "type": "askAgent",
+    "prompt": "The agent just stopped. Do the following in order:\n\n1. VERIFY: Run a real functional test on whatever was changed this session — not just 'no diagnostics'. Exercise the actual code path and report the output. If gamectl was involved, run `python -m livetools gamectl --exe <game.exe> info` and a key sequence test.\n\n2. CONFIRM: State clearly — working or still broken. If broken, state the next concrete step.\n\n3. UPDATE DOCS (scoped correctly):\n   - Game-specific findings (addresses, structs, pitfalls) → update `patches/<GameName>/kb.h`\n   - FFP porting findings → update `.kiro/steering/dx9-ffp-port.md` if it's a general pattern\n   - Reusable tool changes (retools/, livetools/, graphics/) → update `.kiro/steering/tool-catalog.md`\n   - Game-specific scripts in patches/<GameName>/ → never go in tool-catalog.md"
+  }
+}

--- a/.kiro/powers/dx9-ffp-port/POWER.md
+++ b/.kiro/powers/dx9-ffp-port/POWER.md
@@ -1,0 +1,252 @@
+---
+name: "dx9-ffp-port"
+displayName: "DX9 FFP Port"
+description: "DX9 shader-to-FFP proxy porting for RTX Remix compatibility. Covers the full workflow: static analysis, VS constant register discovery, dynamic live tracing, proxy build/deploy, and iteration. Includes draw call routing logic, common pitfalls, and skinning guidance."
+keywords: ["dx9", "directx", "ffp", "rtx-remix", "d3d9", "proxy", "shader", "fixed-function"]
+author: "workspace"
+---
+
+# DX9 FFP Port
+
+Port a DX9 shader-based game to fixed-function pipeline (FFP) for RTX Remix compatibility. Remix requires FFP geometry to inject path-traced lighting and replaceable assets.
+
+**SKINNING IS OFF BY DEFAULT.** Do NOT enable `ENABLE_SKINNING`, modify skinning code, or discuss skinning infrastructure unless the user explicitly asks for character model / bone / skeletal animation support. When requested, read `extensions/skinning/README.md` and `proxy/d3d9_skinning.h` for the full guide.
+
+---
+
+## What the Template Does
+
+The template (`rtx_remix_tools/dx/dx9_ffp_template/`) is a d3d9.dll proxy that:
+
+1. Captures VS constants (View, Projection, World matrices) from `SetVertexShaderConstantF`
+2. Parses `SetVertexDeclaration` to detect BLENDWEIGHT+BLENDINDICES (skinned), POSITIONT (screen-space), NORMAL presence, and per-element byte offsets
+3. Routes `DrawIndexedPrimitive`:
+   - No NORMAL → HUD/UI pass-through
+   - Skinned + `ENABLE_SKINNING=1` → FFP indexed vertex blending
+   - Rigid 3D (has NORMAL) → NULLs shaders, applies FFP transforms
+4. Routes `DrawPrimitive`: world-space (has decl, no POSITIONT, not skinned) → FFP; otherwise pass-through
+5. Applies captured matrices via `SetTransform`
+6. Sets up texture stages and lighting for FFP rendering
+7. Chain-loads RTX Remix (`d3d9_remix.dll`)
+
+## Template File Map
+
+| File | Role |
+|------|------|
+| `proxy/d3d9_device.c` | Core FFP conversion — 119-method `IDirect3DDevice9` wrapper |
+| `proxy/d3d9_main.c` | DLL entry, logging, Remix chain-loading, INI parsing |
+| `proxy/d3d9_wrapper.c` | `IDirect3D9` wrapper — intercepts `CreateDevice` |
+| `proxy/d3d9_skinning.h` | Skinning extension (included only when `ENABLE_SKINNING=1`) |
+| `proxy/build.bat` | MSVC x86 no-CRT build (auto-finds VS via vswhere) |
+| `proxy/d3d9.def` | Exports `Direct3DCreate9` |
+| `proxy/proxy.ini` | Runtime config: `[Remix]` chain load, `[FFP]` AlbedoStage |
+| `extensions/skinning/README.md` | Guide for enabling skinning (late-stage) |
+
+Per-game copies live at `patches/<GameName>/` (copy the whole template directory).
+
+---
+
+## Porting Workflow
+
+### Step 1: Static Analysis
+
+Run the template's scripts to understand the game's D3D9 usage:
+
+```bash
+python rtx_remix_tools/dx/dx9_ffp_template/scripts/find_d3d_calls.py "<game.exe>"
+python rtx_remix_tools/dx/dx9_ffp_template/scripts/find_vs_constants.py "<game.exe>"
+python rtx_remix_tools/dx/dx9_ffp_template/scripts/decode_vtx_decls.py "<game.exe>" --scan
+python rtx_remix_tools/dx/dx9_ffp_template/scripts/find_device_calls.py "<game.exe>"
+```
+
+Scripts are fast first-pass scanners — surface candidate addresses only. Always follow up with `retools` and `livetools` for deep analysis.
+
+Key things to find:
+- How the game obtains its D3D device (Direct3DCreate9 → CreateDevice)
+- Which functions call `SetVertexShaderConstantF` and with what register/count patterns
+- What vertex declaration formats are used (BLENDWEIGHT/BLENDINDICES = skinning)
+- Where the main render loop / draw calls live
+
+### Step 2: Discover VS Constant Register Layout
+
+This is the **most critical** step. Determine which VS constant registers hold View, Projection, and World matrices.
+
+**Static approach:** Decompile call sites:
+```bash
+python -m retools.decompiler <game.exe> <call_site_addr> --types patches/<project>/kb.h
+```
+
+**Dynamic approach:** Trace `SetVertexShaderConstantF` live:
+```bash
+python -m livetools trace <call_addr> --count 50 \
+    --read "[esp+8]:4:uint32; [esp+10]:4:uint32; *[esp+c]:64:float32"
+```
+Captures: startRegister, Vector4fCount, and the first 4 vec4 constants of actual float data.
+
+**How to identify matrices:**
+- View matrix: changes with camera movement; contains camera orientation
+- Projection matrix: contains aspect ratio and FOV; rarely changes
+- World matrix: changes per object; contains position/rotation/scale
+- Look for 4×4 matrices (16 floats = 4 registers). Row 3 often has `[0, 0, 0, 1]` for affine transforms.
+
+### Step 3: Copy Template and Update Defines
+
+1. Copy `rtx_remix_tools/dx/dx9_ffp_template/` to `patches/<GameName>/`
+2. Update the `GAME-SPECIFIC` section in `proxy/d3d9_device.c` (top of file)
+3. Update `kb.h` with discovered function signatures, structs, and globals
+
+### Step 4: Build and Deploy
+
+```bash
+cd patches/<GameName>/proxy
+build.bat
+```
+
+Copy `d3d9.dll` + `proxy.ini` to the game directory. Place `d3d9_remix.dll` there too if using Remix.
+
+### Step 5: Diagnose with Log
+
+The proxy writes `ffp_proxy.log` in the game directory after a 50-second delay, then logs 3 frames of detailed draw call data:
+
+- **VS regs written**: which constant registers the game actually fills
+- **Vertex declarations**: what vertex elements each draw uses
+- **Draw calls**: primitive type, vertex count, index count, textures per stage
+- **Matrices**: actual View/Proj/World values being applied
+
+Do not change the logging delay unless the user asks — it ensures the user gets into the game with real geometry before logging begins.
+
+**Tell the user when you need them to interact with the game** for logging or hooking purposes. They must be in-game with geometry visible for the log to be useful.
+
+---
+
+## Game-Specific Defines
+
+The top of `proxy/d3d9_device.c` has a `GAME-SPECIFIC` section:
+
+```c
+#define VS_REG_VIEW_START       0   // First register of view matrix
+#define VS_REG_VIEW_END         4
+#define VS_REG_PROJ_START       4   // First register of projection matrix
+#define VS_REG_PROJ_END         8
+#define VS_REG_WORLD_START     16   // First register of world matrix
+#define VS_REG_WORLD_END       20
+// Bone defines below only matter when ENABLE_SKINNING=1 (off by default)
+#define VS_REG_BONE_THRESHOLD  20
+#define VS_REGS_PER_BONE        3
+#define VS_BONE_MIN_REGS        3
+#define ENABLE_SKINNING         0   // Only set to 1 after rigid FFP works
+```
+
+---
+
+## Architecture: What to Edit vs What to Leave Alone
+
+| Section | Approx Lines | Edit Per-Game? |
+|---------|-------------|----------------|
+| `VS_REG_*` and `ENABLE_SKINNING` defines | 29–53 | **YES** |
+| D3D9 constants, enums, vtable slot indices | 54–257 | NO |
+| `WrappedDevice` struct | 258–337 | NO |
+| `FFP_SetupLighting`, `FFP_SetupTextureStages`, `FFP_ApplyTransforms` | 367–486 | MAYBE |
+| `FFP_Engage` / `FFP_Disengage` | 487–559 | NO |
+| IUnknown + relay thunks | 560–683 | NO — naked ASM, never edit |
+| `WD_Reset` / `WD_Present` / `WD_BeginScene` / `WD_EndScene` | 684–780 | NO |
+| `WD_DrawPrimitive` | 781–824 | **YES** — draw routing |
+| `WD_DrawIndexedPrimitive` | 825–993 | **YES** — main draw routing |
+| `WD_SetVertexShaderConstantF` | 995–1085 | MAYBE — dirty tracking |
+| `WD_SetVertexDeclaration` | 1134–1293 | MAYBE — element parsing |
+| `WrappedDevice_Create` + vtable wiring | 1297–1476 | NO |
+
+### DrawIndexedPrimitive Decision Tree
+
+```
+viewProjValid?
+├─ NO  → shader passthrough
+└─ YES
+    ├─ curDeclIsSkinned?
+    │   ├─ YES + ENABLE_SKINNING=1 → FFP skinned draw (or passthrough on failure)
+    │   └─ YES + ENABLE_SKINNING=0 → shader passthrough
+    └─ NOT skinned
+        ├─ !curDeclHasNormal → shader passthrough (HUD/UI)
+        └─ hasNormal → FFP_Engage + rigid FFP draw
+```
+
+**Common per-game changes:**
+- World geometry omits NORMAL → remove or change `!curDeclHasNormal` filter
+- Special passes (shadow, reflection) → filter by shader pointer, render target, or vertex count
+- UI drawn with DrawIndexedPrimitive + NORMAL → add a filter (e.g. check stride or texture)
+
+### DrawPrimitive Decision Tree
+
+```
+viewProjValid AND lastDecl AND !curDeclHasPosT AND !curDeclIsSkinned?
+├─ YES → FFP_Engage (world-space particles / non-indexed geometry)
+└─ NO  → shader passthrough (screen-space UI, POSITIONT, no decl, skinned)
+```
+
+---
+
+## Analysis Scripts Reference
+
+| Script | What it surfaces |
+|--------|-----------------|
+| `scripts/find_d3d_calls.py <game.exe>` | D3D9/D3DX imports and call sites |
+| `scripts/find_vs_constants.py <game.exe>` | `SetVertexShaderConstantF` call sites and register/count args |
+| `scripts/find_device_calls.py <game.exe>` | Device vtable call patterns and device pointer refs |
+| `scripts/find_vtable_calls.py <game.exe>` | D3DX constant table usage and D3D9 vtable calls |
+| `scripts/decode_vtx_decls.py <game.exe> --scan` | Vertex declaration formats (BLENDWEIGHT/BLENDINDICES → skinning) |
+| `scripts/scan_d3d_region.py <game.exe> 0xSTART 0xEND` | Map all D3D9 vtable calls in a code region |
+
+---
+
+## RE Tool Workflows for FFP Porting
+
+### Find all SetVertexShaderConstantF call sites
+```bash
+python -m retools.xrefs <game.exe> <iat_addr> -t call
+```
+
+### Decompile a VS constant setup function
+```bash
+python -m retools.decompiler <game.exe> <func_addr> --types patches/<project>/kb.h
+```
+
+### Trace live VS constant writes
+```bash
+python -m livetools trace <SetVSConstF_call_addr> --count 50 \
+    --read "[esp+8]:4:uint32; [esp+10]:4:uint32; *[esp+c]:64:float32"
+```
+
+### Count draw calls and find callers
+```bash
+python -m livetools dipcnt on
+# wait in-game
+python -m livetools dipcnt read
+python -m livetools dipcnt callers 100
+```
+
+### Understand render path depth
+```bash
+python -m retools.callgraph <game.exe> <render_func_addr> --down 3
+```
+
+### Understand a specific draw call path
+```bash
+python -m livetools steptrace <draw_func_addr> --max-insn 1000 --call-depth 1 --detail branches
+```
+
+### Find vertex declaration setup
+```bash
+python -m retools.search <game.exe> strings -f "vertex,decl,shader" --xrefs
+```
+
+---
+
+## Common Pitfalls
+
+- **Matrices look wrong**: D3D9 FFP `SetTransform` expects row-major. The proxy transposes. If the game stores matrices row-major in VS constants (uncommon), remove the transpose in `FFP_ApplyTransforms`.
+- **Everything is white/black**: Albedo texture is on stage 1+, not stage 0. Set `AlbedoStage` in `proxy.ini`, or trace `SetTexture` calls to find the correct stage.
+- **Some objects render, others don't**: Check whether missing geometry has NORMAL in its vertex decl. Check `viewProjValid` is true at draw time. DrawPrimitive routes on decl presence + no POSITIONT + not skinned.
+- **Skinned meshes invisible**: Enable `ENABLE_SKINNING 1`. Check log for `skinExpDecl: 00000000` (CreateVertexDeclaration failed). Verify `boneStartReg` and `numBones` are non-zero.
+- **Game crashes on startup**: Set `Enabled=0` in `proxy.ini [Remix]` to test without Remix.
+- **Geometry at origin / piled up**: World matrix register mapping wrong. Re-examine VS constant writes via `livetools trace`.
+- **World geometry shifts after skinned draws**: `WORLDMATRIX(0)` clobbered by bone[0]. The proxy sets `worldDirty=1` for re-application. If still broken, check for bone register overlap with world matrix range.

--- a/.kiro/powers/dynamic-analysis/POWER.md
+++ b/.kiro/powers/dynamic-analysis/POWER.md
@@ -1,0 +1,356 @@
+---
+name: "dynamic-analysis"
+displayName: "Dynamic Analysis"
+description: "Frida-based live process analysis toolkit for reverse engineering. Use when attaching to a running process, tracing functions, collecting execution data, inspecting registers/memory/stack at runtime, stepping through code, patching live memory, or analyzing JSONL trace dumps."
+keywords: ["frida", "dynamic-analysis", "reverse-engineering", "tracing", "breakpoints", "memory", "livetools"]
+author: "workspace"
+---
+
+# Dynamic Analysis with livetools
+
+For DX9 FFP proxy porting and RTX Remix compatibility, see also the `dx9-ffp-port` power.
+
+A live analysis toolkit for running processes. Attach, trace functions, collect data, inspect state, step through code, patch memory, analyze offline — composable tools that chain naturally for any RE scenario.
+
+All commands: `python -m livetools <command> [args]`
+
+---
+
+## Quick Reference
+
+### Session
+```
+python -m livetools attach <name_or_pid>     # start daemon, attach Frida
+python -m livetools detach                    # release target, stop daemon
+python -m livetools status                    # check state
+```
+
+### Breakpoints (blocking)
+```
+python -m livetools bp add <addr>             # set blocking code breakpoint
+python -m livetools bp del <addr>             # remove breakpoint
+python -m livetools bp list                   # list all BPs + hit counts
+```
+
+### Wait for Hit
+```
+python -m livetools watch --timeout 60        # block until BP hit (returns snapshot)
+```
+
+### Inspect (while frozen)
+```
+python -m livetools regs                      # all registers
+python -m livetools stack [N]                 # top N dwords from ESP (default 16)
+python -m livetools mem read <addr> <size>    # hex dump + multi-type interpretation
+python -m livetools mem read <addr> <size> --as float32
+python -m livetools disasm [addr] [-n count]  # disassemble (default: EIP, 16 insns)
+python -m livetools bt                        # call stack backtrace
+```
+
+Supported `--as` types: `float32`, `float64`, `half`, `uint8`, `int8`, `uint16`, `int16`, `uint32`, `int32`, `ptr`, `ascii`, `utf16`.
+
+### Control
+```
+python -m livetools step [over|into|out]      # advance one instruction (returns snapshot)
+python -m livetools resume                    # unfreeze target
+```
+
+### Patch + Scan (anytime)
+```
+python -m livetools mem write <addr> <hex>    # write bytes to live memory
+python -m livetools scan <pattern> --range START:SIZE
+```
+
+### Non-blocking Tracing
+```
+python -m livetools trace <addr> [--count N] [--read SPEC] [--read-leave SPEC] [--filter EXPR] [--timeout T] [--output FILE]
+python -m livetools steptrace <addr> [--max-insn N] [--call-depth D] [--detail LEVEL] [--timeout T] [--output FILE]
+python -m livetools collect <addr> [addr2 ...] [--duration N] [--read SPEC] [--fence ADDR] [--label ADDR=NAME] [--output FILE]
+python -m livetools modules [--filter PATTERN]
+python -m livetools analyze <file.jsonl> [--summary] [--group-by FIELD] [--filter EXPR] [--cross-tab F1 F2] [--histogram FIELD] [--export-csv FILE]
+```
+
+---
+
+## Read Spec Format
+
+Used by `trace`, `collect`, and related commands to specify what data to capture at function entry/exit.
+
+Semicolon-separated fields. Each field:
+
+| Syntax | Description | Example |
+|--------|-------------|---------|
+| `register` | Register value as hex | `ecx`, `eax`, `ebp` |
+| `[reg+OFFSET]:SIZE:TYPE` | Read SIZE bytes from reg+OFFSET | `[esp+4]:12:float32` |
+| `*[reg+OFFSET]:SIZE:TYPE` | Double-deref: follow pointer first | `*[esp+4]:64:float32` |
+| `st0` | FPU top-of-stack (best-effort) | `st0` |
+
+Types: `hex` (default), `float32`, `float64`, `uint32`, `int32`, `uint16`, `int16`, `uint8`, `int8`, `ascii`, `utf16`, `ptr`
+
+Example read spec:
+```
+"ecx; [esp+4]:12:float32; *[ecx+0x10]:64:hex"
+```
+
+## Filter Spec Format
+
+Simple comparison on a readable field. Evaluated in-agent; non-matching calls are silently skipped.
+
+```
+[esp+8]==0x2
+eax!=0
+[ecx+0x54]:4:float32>0.5
+```
+
+---
+
+## Command Details
+
+### trace — Non-blocking enter/leave function hook
+
+Hooks a function's entry and exit **without freezing** the target. Reads specified data at each call, returns structured results.
+
+```bash
+# 10 calls, read ECX + 12 bytes at [esp+4] as float32
+python -m livetools trace 0x401000 --count 10 --read "ecx; [esp+4]:12:float32"
+
+# Filter: only record when stack arg == 2
+python -m livetools trace 0x402000 --count 5 --filter "[esp+8]==0x2" --read "[esp+c]:64:float32"
+
+# Read different things on enter vs leave
+python -m livetools trace 0x403000 --count 20 --read "ecx; [esp+4]:12:float32" --read-leave "eax"
+
+# Write output to JSONL file
+python -m livetools trace 0x401000 --count 100 --read "ecx" --output trace.jsonl
+```
+
+Output format:
+```
+=== TRACE 0x00401000 === 10 samples
+
+#1  caller=00405ABC
+  ENTER  ecx=10B457CC  [esp+4]:12:float32=[-622.44, -278.34, 50.00]
+  LEAVE  eax=00000001  retval=00000001
+```
+
+### steptrace — Instruction-level execution recording via Stalker
+
+Records every instruction executed from function entry through return. Uses Frida Stalker for real-time instruction tracing.
+
+```bash
+# Full trace, follow 1 level of subcalls
+python -m livetools steptrace 0x401000 --max-insn 500 --call-depth 1 --detail full
+
+# Branches only (default, lighter weight)
+python -m livetools steptrace 0x402000 --max-insn 1000 --detail branches
+
+# Block-level only (cheapest, for huge functions)
+python -m livetools steptrace 0x403000 --max-insn 5000 --detail blocks
+
+# Save to file for later analysis
+python -m livetools steptrace 0x401000 --max-insn 500 --output steptrace.jsonl
+```
+
+Detail levels:
+- **full**: Every instruction, register snapshots at calls/rets. Expensive but complete.
+- **branches**: All instructions recorded, register snapshots at branches. Good default.
+- **blocks**: Only instruction addresses. Cheapest. Good for path mapping.
+
+### collect — Long-running multi-function data collection
+
+Streams data from one or more functions for a duration. Optionally partitions records into intervals via fence hooks.
+
+```bash
+# Collect two functions for 30s, partitioned by a frame-boundary function
+python -m livetools collect 0x401000 0x402000 \
+  --duration 30 --output trace.jsonl \
+  --read "ecx; [esp+4]:12:float32" \
+  --fence 0x403000 \
+  --label 0x401000=FuncA --label 0x402000=FuncB
+
+# Collect with per-address read specs
+python -m livetools collect 0x401000 0x402000 \
+  --read@0x401000="ecx; [esp+4]:12:float32" \
+  --read@0x402000="ecx; [esp+4]:28:hex" \
+  --duration 15 --output multi.jsonl
+```
+
+The **fence** concept: Hook a boundary function (e.g. DX Present) that increments an interval counter. Every trace record includes the current interval ID. Enables per-frame analysis, per-N-calls partitioning, and cross-function correlation.
+
+Output: JSONL in `patches/<exe_name>/traces/` by default (gitignored).
+
+### modules — List loaded DLLs
+
+```bash
+python -m livetools modules
+python -m livetools modules --filter kernel
+```
+
+Returns name, base address, size, and full path for every loaded module. Essential for finding DLL bases for vtable hooks.
+
+### analyze — Offline JSONL aggregation (no Frida needed)
+
+Pure Python. Reads JSONL from `collect` or `trace --output`. Deterministic, non-hallucinated aggregation.
+
+```bash
+python -m livetools analyze trace.jsonl --summary
+python -m livetools analyze trace.jsonl --group-by addr
+python -m livetools analyze trace.jsonl --filter "addr==00401000" --group-by "leave.eax"
+python -m livetools analyze trace.jsonl --filter "addr==00401000" --cross-tab caller leave.eax
+python -m livetools analyze trace.jsonl --group-by interval --top 5
+python -m livetools analyze trace.jsonl --interval 47
+python -m livetools analyze trace.jsonl --compare-intervals 10 50
+python -m livetools analyze trace.jsonl --filter "addr==00401000" --histogram "enter.reads.0.value.0"
+python -m livetools analyze trace.jsonl --filter "addr==00401000" --export-csv output.csv
+```
+
+Field path syntax: dot-separated with array indices.
+- `addr` = hooked address
+- `leave.eax` = EAX at exit
+- `enter.reads.0.value.0` = first read spec's first float value
+- `interval` = fence counter
+- `caller` = return address
+
+---
+
+## JSONL Record Format
+
+Each line in a JSONL file is a self-contained JSON object:
+
+```json
+{"ts": 1710000000000, "interval": 47, "addr": "0x00401000", "label": "FuncA", "caller": "00405ABC", "enter": {"regs": {"ecx": "10B457CC"}, "reads": [{"spec": "[esp+4]:12:float32", "value": [-622.44, -278.34, 50.00]}]}, "leave": {"eax": "00000001", "retval": "00000001", "reads": []}}
+```
+
+---
+
+## Output File Location
+
+JSONL files default to `patches/<exe_name>/traces/` inside the workspace (gitignored). The exe name is auto-detected from the attached process. Override with `--output /absolute/path.jsonl`.
+
+---
+
+## The Debugger Snapshot
+
+Every `watch` (on hit) and `step` (after advancing) returns a unified snapshot:
+
+```
+=== BREAKPOINT HIT === 0x00401000 (bp#1, hit #3)
+
+Registers:
+  EAX=00000001  EBX=00000000  ECX=008800A0  EDX=00405678
+  ESI=008900B4  EDI=007A0000  EBP=0019FE40  ESP=0019FD00
+  EIP=00401000
+
+Stack [ESP=0019FD00]:
+  +00: 00405678  +04: 0019FE80  +08: 00000000  +0C: 00000000
+
+Disasm @ EIP:
+> 00401000  sub   esp, 0x234
+  00401006  push  ebp
+```
+
+---
+
+## Workflow Recipes
+
+### Recipe 1: Quick function behavior check (trace)
+
+Non-blocking — target keeps running. See what arguments a function receives and what it returns.
+
+```bash
+python -m livetools trace 0x401000 --count 10 --read "ecx; [esp+4]:12:float32"
+```
+
+### Recipe 2: Understand a function's code path (steptrace)
+
+```bash
+python -m livetools steptrace 0x401000 --max-insn 500 --call-depth 1 --detail branches
+```
+
+### Recipe 3: Per-frame analysis (collect + fence + analyze)
+
+```bash
+python -m livetools collect 0x401000 0x402000 \
+  --duration 30 --fence 0x403000 \
+  --read "ecx; [esp+4]:12:float32" \
+  --label 0x401000=FuncA --label 0x402000=FuncB \
+  --output trace.jsonl
+
+python -m livetools analyze trace.jsonl --summary
+python -m livetools analyze trace.jsonl --group-by "leave.eax"
+python -m livetools analyze trace.jsonl --compare-intervals 10 50
+python -m livetools analyze trace.jsonl --histogram "enter.reads.0.value.0"
+```
+
+### Recipe 4: Find DLL base for vtable hooks
+
+```bash
+python -m livetools modules --filter kernel
+```
+
+### Recipe 5: Register inspection at a breakpoint
+
+```bash
+python -m livetools bp add 0x401000
+python -m livetools watch --timeout 60
+python -m livetools resume
+```
+
+### Recipe 6: Read struct fields from a register pointer
+
+After a snapshot shows ECX=008800A0 and you suspect a float at offset +0x54:
+```bash
+python -m livetools mem read 0x008800F4 4 --as float32
+```
+
+### Recipe 7: Step through a function
+
+```bash
+python -m livetools bp add <function_entry>
+python -m livetools watch --timeout 60
+python -m livetools step over
+python -m livetools step over
+python -m livetools mem read <addr> 32
+python -m livetools resume
+```
+
+### Recipe 8: Patch a byte and verify
+
+```bash
+python -m livetools mem write 0x00401000 "B0 01 C3"
+python -m livetools disasm 0x00401000 -n 3
+```
+
+### Recipe 9: Multi-function data-driven investigation
+
+```bash
+python -m livetools collect 0x401000 0x402000 0x403000 \
+  --duration 60 --fence 0x404000 --output scene.jsonl \
+  --label 0x401000=FuncA --label 0x402000=FuncB --label 0x403000=FuncC
+
+python -m livetools analyze scene.jsonl --summary
+python -m livetools analyze scene.jsonl --group-by addr
+python -m livetools analyze scene.jsonl --filter "addr==0x00401000" --group-by "leave.eax"
+python -m livetools analyze scene.jsonl --filter "addr==0x00401000" --cross-tab caller leave.eax
+python -m livetools analyze scene.jsonl --export-csv scene.csv
+```
+
+---
+
+## Thinking Patterns
+
+1. **Hypothesis first.** Form a hypothesis from static analysis BEFORE tracing. Example: "I think ECX is the visibility struct pointer. Let me verify with trace."
+
+2. **State what you learned.** After inspecting trace data or a snapshot, explicitly state what the values tell you and what question remains.
+
+3. **Use trace before breakpoints.** Non-blocking `trace` is less disruptive than blocking `bp`+`watch`. Start with trace to understand call frequency and typical arguments, then use breakpoints only when you need to freeze and step.
+
+4. **Use collect for volume.** When you need data from thousands of calls across many frames, `collect` with a fence gives you structured JSONL that `analyze` can slice and dice deterministically.
+
+5. **Use analyze for deterministic answers.** Never hallucinate statistics. Always run `analyze` on real collected data to get ground-truth numbers about call counts, return value distributions, per-frame behavior, etc.
+
+6. **Cross-reference with static analysis.** Match live register values and call sites against static disassembly from `retools` to identify struct offsets, vtable slots, and data pointers.
+
+7. **Use modules to find DLL bases.** Before hooking a DLL function (e.g. D3D9 vtable), use `modules` to find the actual loaded base address.
+
+8. **Composable pipeline.** `trace` captures raw records. `collect` streams them to disk. `analyze` aggregates offline. Chain them for any investigation.

--- a/.kiro/steering/dx9-ffp-port.md
+++ b/.kiro/steering/dx9-ffp-port.md
@@ -1,0 +1,267 @@
+﻿---
+description: RTX Remix DX9 FFP porting — per-game folders, address mapping, VS constant discovery, build/deploy, pitfalls.
+inclusion: fileMatch
+fileMatchPattern: "patches/**,rtx_remix_tools/**,**/d3d9_device.c,**/d3d9_main.c,**/d3d9_wrapper.c,**/proxy.ini,**/build.bat"
+---
+
+# RTX Remix — DX9 FFP Porting
+
+The FFP template (`rtx_remix_tools/dx/dx9_ffp_template/`) is a D3D9 proxy DLL that captures VS constant matrices, NULLs shaders on draw calls, applies matrices via `SetTransform`, and chain-loads RTX Remix.
+
+**When to use**: user mentions FFP rendering, DX9 shader-to-FFP conversion, RTX Remix compatibility, or building a `d3d9.dll` proxy for a game.
+
+**SKINNING IS OFF BY DEFAULT.** Do not enable `ENABLE_SKINNING` or discuss skinning unless the user explicitly asks. When asked, read `extensions/skinning/README.md` and `proxy/d3d9_skinning.h`.
+
+---
+
+## Per-Game Folder Rule
+
+Each game gets its own isolated folder. Never edit the template directly. Never share artifacts between games.
+
+```
+patches/<GameName>/
+  kb.h          <- all discovered addresses, structs, globals for THIS game
+  proxy/        <- copy of the template proxy/ for THIS game
+    d3d9_device.c
+    d3d9_main.c
+    d3d9_wrapper.c
+    d3d9_skinning.h
+    d3d9.def
+    build.bat
+    proxy.ini
+  d3d9.dll      <- build output
+  traces/       <- livetools JSONL (gitignored)
+```
+
+Create a new game folder:
+```bash
+xcopy /E /I rtx_remix_tools\dx\dx9_ffp_template patches\<GameName>
+```
+
+---
+
+## Knowledge Base (`patches/<GameName>/kb.h`)
+
+Maintain throughout the session. Pass to every decompiler call: `--types patches/<GameName>/kb.h`.
+
+```c
+// ── Structs (add as discovered via structrefs.py --aggregate) ─────────────────
+
+// ── IAT Addresses ─────────────────────────────────────────────────────────────
+@ 0x______  // IAT: Direct3DCreate9
+@ 0x______  // IAT: IDirect3DDevice9::SetVertexShaderConstantF  (slot 94)
+@ 0x______  // IAT: IDirect3DDevice9::DrawIndexedPrimitive      (slot 82)
+@ 0x______  // IAT: IDirect3DDevice9::DrawPrimitive             (slot 81)
+@ 0x______  // IAT: IDirect3DDevice9::SetVertexDeclaration      (slot 87)
+@ 0x______  // IAT: IDirect3DDevice9::SetTexture                (slot 65)
+@ 0x______  // IAT: IDirect3DDevice9::Present                   (slot 17)
+
+// ── SetVertexShaderConstantF Call Sites ───────────────────────────────────────
+@ 0x______  void __cdecl UploadViewMatrix(IDirect3DDevice9* dev);        // writes c??-c??
+@ 0x______  void __cdecl UploadProjMatrix(IDirect3DDevice9* dev);        // writes c??-c??
+@ 0x______  void __cdecl UploadWorldMatrix(IDirect3DDevice9* dev, ...);  // writes c??-c??
+
+// ── VS Constant Register Layout (fill after tracing) ─────────────────────────
+// View matrix:        c__ - c__  (startReg=__, count=4)
+// Projection matrix:  c__ - c__  (startReg=__, count=4)
+// World matrix:       c__ - c__  (startReg=__, count=4)
+// Bone matrices:      c__ - c__  (startReg=__, count=__ per bone) [if skinned]
+
+// ── Render Loop ───────────────────────────────────────────────────────────────
+@ 0x______  void __cdecl RenderScene(IDirect3DDevice9* dev);
+@ 0x______  void __cdecl RenderObject(IDirect3DDevice9* dev, ...);
+
+// ── Globals ───────────────────────────────────────────────────────────────────
+$ 0x______  IDirect3DDevice9*  g_pDevice
+$ 0x______  IDirect3D9*        g_pD3D
+```
+
+Mark uncertain addresses `// UNVERIFIED`. Remove once confirmed or disproven.
+
+---
+
+## Address Discovery Checklist
+
+Work through these steps in order. Fill `kb.h` as you go.
+
+### Step 1 — Find IAT stubs (fast, static)
+
+```bash
+python -m retools.search <game.exe> imports -d d3d9
+python -m retools.search <game.exe> imports -d d3dx9
+```
+
+Record every `d3d9.dll` and `d3dx9_*.dll` import address into `kb.h` under `IAT Addresses`.
+
+### Step 2 — Find SetVertexShaderConstantF call sites
+
+```bash
+python rtx_remix_tools/dx/dx9_ffp_template/scripts/find_vs_constants.py <game.exe>
+```
+
+For each call site, decompile to see startRegister and count:
+
+```bash
+python -m retools.decompiler <game.exe> <call_site_addr> --types patches/<GameName>/kb.h
+```
+
+### Step 3 — Confirm register layout live
+
+Attach livetools and trace each call site:
+
+```bash
+python -m livetools attach <game.exe>
+python -m livetools trace <SetVSCF_callsite> --count 100 \
+    --read "[esp+8]:4:uint32; [esp+0xC]:4:uint32; *[esp+0x10]:64:float32"
+# reads: startRegister, Vector4fCount, first 4 vec4 floats (dereferenced)
+```
+
+Identify which startReg/count combo produces a 4x4 rotation+translation matrix (View), a perspective matrix (Proj), and per-object transforms (World).
+
+### Step 4 — Find render loop and device pointer
+
+```bash
+python -m graphics.directx.dx9.tracer analyze <trace.jsonl> --render-loop --resolve-addrs <game.exe>
+python -m retools.datarefs <game.exe> <Direct3DCreate9_IAT_addr> --imm
+```
+
+Decompile the render loop entry to find `g_pDevice`:
+
+```bash
+python -m retools.decompiler <game.exe> <render_loop_addr> --types patches/<GameName>/kb.h
+```
+
+### Step 5 — Decode vertex declarations
+
+```bash
+python rtx_remix_tools/dx/dx9_ffp_template/scripts/decode_vtx_decls.py <game.exe> --scan
+```
+
+Look for `BLENDWEIGHT`/`BLENDINDICES` (skinning), `POSITIONT` (screen-space/HUD), `NORMAL` (lit geometry).
+
+---
+
+## Game-Specific Defines
+
+Edit the `GAME-SPECIFIC` block at the top of `patches/<GameName>/proxy/d3d9_device.c`:
+
+```c
+// ── GAME-SPECIFIC — fill from kb.h after RE ───────────────────────────────────
+#define VS_REG_VIEW_START       0   // startRegister of view matrix upload
+#define VS_REG_VIEW_END         4   // exclusive end (start + 4)
+#define VS_REG_PROJ_START       4   // startRegister of projection matrix upload
+#define VS_REG_PROJ_END         8
+#define VS_REG_WORLD_START     16   // startRegister of world/object matrix upload
+#define VS_REG_WORLD_END       20
+#define ENABLE_SKINNING         0   // NEVER set to 1 until rigid FFP is confirmed working
+```
+
+Rules:
+- `*_END = *_START + 4` for a single 4x4 matrix (4 vec4 rows)
+- If View and Proj are uploaded together as one 8-row block, set VIEW_START=0, VIEW_END=4, PROJ_START=4, PROJ_END=8
+- If the game uploads a combined ViewProj, treat it as View (START=0, END=4) and leave Proj as identity
+
+---
+
+## What to Edit vs Leave Alone
+
+| Section in d3d9_device.c | Edit per-game? | Notes |
+|--------------------------|---------------|-------|
+| `VS_REG_*` defines | YES | Primary per-game config |
+| `ENABLE_SKINNING` define | NO (default 0) | Only after rigid FFP confirmed |
+| `FFP_ApplyTransforms` | MAYBE | Only if matrix row-major/column-major mismatch |
+| `FFP_SetupLighting` | MAYBE | Only if lighting looks wrong |
+| `FFP_SetupTextureStages` | MAYBE | Only if textures missing/wrong |
+| `WD_DrawIndexedPrimitive` | YES | Draw routing logic |
+| `WD_DrawPrimitive` | YES | Draw routing logic |
+| IUnknown thunks | NO | Naked ASM — never touch |
+| All other relay thunks | NO | Auto-generated, never touch |
+
+---
+
+## Draw Routing Decision Trees
+
+### DrawIndexedPrimitive
+
+```
+Has vertex decl?
+├── NO  → passthrough (HUD/UI, no NORMAL)
+└── YES → has NORMAL?
+    ├── NO  → passthrough (screen-space or unlit)
+    └── YES → ENABLE_SKINNING == 1 AND has BLENDWEIGHT?
+        ├── YES → FFP skinned draw
+        └── NO  → FFP rigid draw (NULL shader + SetTransform)
+```
+
+### DrawPrimitive
+
+```
+Has vertex decl?
+├── NO  → passthrough
+└── YES → has NORMAL?
+    ├── NO  → passthrough
+    └── YES → FFP rigid draw (same as DIP rigid path)
+```
+
+**viewProjValid gate**: both paths check `viewProjValid` before FFP conversion. If View or Proj matrix was never uploaded (registers never written), `viewProjValid` stays false and all draws passthrough. This is the most common cause of "nothing renders" on first run.
+
+---
+
+## Build and Deploy
+
+```bash
+# Build (from game's proxy folder)
+cd patches\<GameName>\proxy
+build.bat
+
+# Deploy to game directory
+copy d3d9.dll  <game_dir>\d3d9.dll
+copy proxy.ini <game_dir>\proxy.ini
+```
+
+`build.bat` uses `vswhere` to auto-locate MSVC. Requires Visual Studio with C++ workload installed.
+
+`proxy.ini` minimum config:
+```ini
+[Remix]
+Enabled=1
+Chain.DLL=
+
+[Proxy]
+AlbedoStage=0
+LogDelaySec=50
+```
+
+Set `Enabled=0` to test the proxy without Remix (geometry should still render correctly).
+
+---
+
+## Log Diagnosis (`ffp_proxy.log`)
+
+The proxy writes `ffp_proxy.log` in the game directory after `LogDelaySec` seconds (default 50). Always check this first.
+
+| Log entry | Meaning | Action |
+|-----------|---------|--------|
+| `viewProjValid=0` at draw time | View/Proj registers never written | Re-check VS_REG_VIEW/PROJ_START values |
+| `worldValid=0` at draw time | World register never written | Re-check VS_REG_WORLD_START |
+| `DIP passthrough (no decl)` | Draw has no vertex declaration | Expected for HUD — verify it's not 3D geometry |
+| `DIP passthrough (no NORMAL)` | Vertex decl lacks NORMAL element | Check `decode_vtx_decls.py` output |
+| `FFP draw: world=identity` | World matrix is all-zeros or identity | World register mapping wrong |
+| `SetVSCF reg=N count=M` | Constant upload logged | Verify N matches VS_REG_*_START |
+| `Chain load failed` | Remix DLL not found | Check `Chain.DLL` path in proxy.ini |
+
+---
+
+## Common Pitfalls
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| All geometry at world origin | Wrong world matrix register | Re-trace `SetVertexShaderConstantF`, check startReg for per-object uploads |
+| Camera/view wrong | View and Proj registers swapped | Swap VS_REG_VIEW_START and VS_REG_PROJ_START |
+| Objects white or black | Albedo texture on wrong stage | Trace `SetTexture`, set `AlbedoStage` in proxy.ini |
+| Nothing renders at all | `viewProjValid` never set | Wrong VIEW/PROJ register range — check log |
+| Game crashes on startup | Remix chain-load failure | Set `Enabled=0` in proxy.ini to isolate |
+| Geometry renders but Remix doesn't inject | Remix not in game dir or wrong chain | Check `Chain.DLL` path |
+| Skinned meshes T-pose | Skinning not implemented | Enable `ENABLE_SKINNING=1` only after rigid FFP works |
+| Matrix looks transposed | Game stores row-major in VS constants | Remove transpose in `FFP_ApplyTransforms` |
+| HUD/UI geometry broken | HUD draws being FFP-converted | Ensure passthrough for no-NORMAL vertex decls |

--- a/.kiro/steering/engineering-standards.md
+++ b/.kiro/steering/engineering-standards.md
@@ -1,0 +1,61 @@
+---
+description: Engineering standards, design principles, and code comment rules for this workspace.
+inclusion: auto
+---
+
+# Engineering Standards
+
+Every change should make the codebase better, not just make the problem go away. If a solution needs a paragraph to justify why it's not a hack, it's a hack.
+
+## Remove
+
+- **Fixes in the wrong layer**: a guard on a canvas to suppress commits that a model should own. Put the fix where the problem originates.
+- **Tolerance inflation**: widening deltas or adding retries to hide flaky behavior. If the value is wrong, find out why.
+- **Catch-all exception swallowing**: `try/except Exception: pass` to hide symptoms.
+- **Excessive error/null handling**: adding too many error/None "if" checks. If the error is expected, handle it. If unexpected, raise it.
+- **God methods**: 200+ line functions doing multiple things. Break into named steps. Focus on cognitive load. Design for fewer indentation levels.
+- **Leaky abstractions**: implementation details leaking into layers/modules that should be agnostic of one another.
+
+## Design For
+
+- **Single responsibility**: one component, one job. If you need "and" to describe it, split it.
+- **Ownership**: the component that creates the problem owns the fix.
+- **Minimal public surface**: expose what consumers need, nothing more.
+
+## Commit to the New Code
+
+- **No legacy fallbacks**: if you replace a system, remove the old one.
+- **No dead code**: commented-out blocks, unused imports, orphan functions "just in case". Version control is the safety net.
+- **No multiple paths to the same result**: one way to do each thing. If two paths exist, one is wrong.
+- **No half-migrations**: finish the job — update every reference, remove old APIs.
+
+## Smell Tests
+
+- "It works if I add a sleep" — broken data flow.
+- "It works if I read from widget instead of storage" — the two are out of sync.
+- "It passes alone but fails with other tests" — shared mutable state leaking.
+- "I added a flag to skip this code path" — why does that path run in the first place?
+
+## Code Comments
+
+Each file reads as if it was always designed this way. Comments guide the next developer, not narrate the development journey.
+
+### Remove
+
+- **Implementation backstories**: "We do this because the other day X happened"
+- **Obvious narration**: "Create the attribute", "Loop through keys" — if the code says it, the comment is noise
+- **Debugging breadcrumbs**: "Without this, subsequent tests may see the modifier key as still held"
+- **Trial-and-error reasoning**: "We tried X but it caused Y so we do Z instead"
+
+### Keep
+
+- **Non-obvious design decisions**: stated as *what* and *why this design*, not *what happened to us*
+- **Tricky invariants**: conditions that would be easy to accidentally break
+- **API contracts**: docstrings on public methods with Args, Returns, Raises
+
+### Prefer Instead
+
+- **Rename** a variable or function to be self-explanatory rather than adding a comment
+- **Docstrings** on classes and public methods (Google style: `Args:`, `Returns:`, `Raises:`)
+- **Type hints** over comments about expected types
+- **Short inline comments** on the *why*, never the *what*

--- a/.kiro/steering/tool-catalog.md
+++ b/.kiro/steering/tool-catalog.md
@@ -1,0 +1,330 @@
+---
+description: Complete reference for all RE tools — retools (static analysis), livetools (dynamic/Frida), and dx9 tracer. Consult before choosing any tool.
+inclusion: auto
+---
+
+# Tool Catalog
+
+All tools work on PE binaries (`.exe` and `.dll`). `$B` = path to binary, `$VA` = hex address, `$D` = path to minidump `.dmp` file. Check tools help command for more info on usage.
+
+Always consult this catalog before making any move to take the best decision on what to use with best bang for your buck.
+
+IMPORTANT: Collecting MORE INFORMATION per command run is encouraged over minor snippets of data/output that don't reveal the whole picture.
+
+## Static Analysis (`retools/`) — offline, on-disk PE files
+
+| Tool | Purpose | Example |
+|------|---------|---------|
+| `disasm.py $B $VA` | Disassemble N instructions at VA | `disasm.py binary.exe 0x401000 -n 50` |
+| `decompiler.py $B $VA` | Ghidra-quality C decompilation (r2ghidra, auto-configured) | `python -m retools.decompiler binary.exe 0x401000` |
+| `decompiler.py $B $VA --types` | Decompile with knowledge base (structs, func sigs, globals) | `python -m retools.decompiler binary.exe 0x401000 --types patches/proj/kb.h` |
+| `funcinfo.py $B $VA` | Find function start/end, rets, calling convention, callees | `funcinfo.py binary.exe 0x401000` |
+| `cfg.py $B $VA` | Control flow graph (basic blocks + edges, text or mermaid) | `cfg.py binary.exe 0x401000 --format mermaid` |
+| `callgraph.py $B $VA` | Caller/callee tree (multi-level, --up/--down N) | `callgraph.py binary.exe 0x401000 --up 3` |
+| `xrefs.py $B $VA` | Find all calls/jumps TO an address | `xrefs.py binary.exe 0x401000 -t call` |
+| `datarefs.py $B $VA` | Find instructions that reference a global address | `datarefs.py binary.exe 0x7A0000 --imm` |
+| `structrefs.py $B $OFF` | Find all `[reg+offset]` accesses (struct field usage) | `structrefs.py binary.exe 0x54 --base esi` |
+| `structrefs.py $B --aggregate` | Reconstruct C struct from all field accesses in a function | `structrefs.py binary.exe --aggregate --fn 0x401000 --base esi` |
+| `vtable.py $B dump $VA` | Dump C++ vtable slots with instruction preview | `vtable.py binary.exe dump 0x6A0000` |
+| `vtable.py $B calls $OFF` | Find all indirect `call [reg+offset]` (vtable call sites) | `vtable.py binary.exe calls 0xB0` |
+| `rtti.py $B vtable $VA` | Resolve C++ class name + inheritance chain from vtable (MSVC RTTI) | `rtti.py binary.dll vtable 0x6A0000` |
+| `rtti.py $B throwinfo $RVA` | Resolve exception type from `_ThrowInfo` (MSVC RTTI) | `rtti.py binary.dll throwinfo 0x5040CF8` |
+| `search.py $B strings` | Extract strings with keyword filter | `search.py binary.exe strings -f render,draw` |
+| `search.py $B strings --xrefs` | Find strings AND code locations that reference them | `search.py binary.exe strings -f "error" --xrefs` |
+| `search.py $B pattern` | Find exact byte pattern | `search.py binary.exe pattern "D9 56 54 D8 1D"` |
+| `search.py $B imports` | List PE imports, filter by DLL | `search.py binary.exe imports -d kernel32` |
+| `search.py $B exports` | List PE exports, filter by keyword | `search.py binary.dll exports -f Create` |
+| `search.py $B insn` | Find instructions by mnemonic/operand pattern | `search.py binary.dll insn "mov *,0x10000"` |
+| `search.py $B insn --near` | Find instructions near another pattern | `search.py binary.dll insn "mov *,0x10000" --near "cmp *,0x10000" --range 0x400` |
+| `readmem.py $B $VA $TYPE` | Read typed data (float, uint32, ptr, bytes...) | `readmem.py binary.exe 0x401000 float` |
+| `asi_patcher.py build` | Generate .asi DLL patch from JSON spec | `asi_patcher.py build spec.json --vcvarsall ...` |
+| `throwmap.py $B list` | List all throw sites and their MSVC exception strings | `python -m retools.throwmap binary.exe list` |
+| `throwmap.py $B match --dump $D` | Match a minidump crash stack against the throw map to identify the throw site | `python -m retools.throwmap binary.exe match --dump crash.dmp` |
+
+## Minidump Analysis (`retools/dumpinfo.py`) — crash dump files
+
+| Tool | Purpose | Example |
+|------|---------|---------|
+| `dumpinfo.py $D info` | Crash dump overview: modules, exception summary | `dumpinfo.py crash.dmp info` |
+| `dumpinfo.py $D threads` | All threads with registers resolved to module+offset | `dumpinfo.py crash.dmp threads` |
+| `dumpinfo.py $D threads --verbose` | Full register dump per thread | `dumpinfo.py crash.dmp threads --verbose` |
+| `dumpinfo.py $D stack $TID` | Stack walk: return addresses, annotated values | `dumpinfo.py crash.dmp stack 67900` |
+| `dumpinfo.py $D stack $TID --depth N` | Stack walk with custom slot depth (default 512) | `dumpinfo.py crash.dmp stack 67900 --depth 1024` |
+| `dumpinfo.py $D stackscan $TID` | Scan thread stack for code addresses by module | `dumpinfo.py crash.dmp stackscan 67900` |
+| `dumpinfo.py $D stackscan $TID --module X` | Filter stackscan to a specific module | `dumpinfo.py crash.dmp stackscan 67900 --module game.exe` |
+| `dumpinfo.py $D exception` | Exception record, MSVC C++ type name decoding | `dumpinfo.py crash.dmp exception` |
+| `dumpinfo.py $D read $VA $T` | Read typed data from dump memory | `dumpinfo.py crash.dmp read 0x7FFE0030 uint64` |
+| `dumpinfo.py $D strings` | Extract strings from dump memory (optional regex filter) | `dumpinfo.py crash.dmp strings --pattern "error"` |
+| `dumpinfo.py $D memscan $PAT` | Search dump memory for byte or text pattern | `dumpinfo.py crash.dmp memscan "48 65 6C 6C 6F"` |
+| `dumpinfo.py $D memmap` | List all captured memory regions in the dump | `dumpinfo.py crash.dmp memmap` |
+| `dumpinfo.py $D diagnose` | One-shot crash analysis pipeline (exception + stack + throw match) | `dumpinfo.py crash.dmp diagnose --binary game.exe` |
+
+## Dynamic Analysis (`livetools/`) — Frida-based, attaches to running process
+
+```
+python -m livetools attach <process>    # start session
+python -m livetools detach              # end session
+python -m livetools status              # check connection
+```
+
+| Command | Purpose |
+|---------|---------|
+| `trace $VA` | Non-blocking: log N hits with register/memory reads |
+| `steptrace $VA` | Instruction-level trace (Stalker) with call depth control |
+| `collect $VA [$VA2...]` | Multi-address hit counting over duration |
+| `bp add/del/list $VA` | Breakpoints (stops target) |
+| `watch` | Wait for breakpoint hit |
+| `regs` / `stack` / `bt` | Inspect registers, stack, backtrace at break |
+| `mem read $VA $SIZE` | Read live process memory (supports --as float32) |
+| `mem write $VA $HEX` | Write live process memory |
+| `mem alloc $SIZE` | Allocate RWX memory in the target process, returns address |
+| `disasm [$VA]` | Disassemble from live process |
+| `scan $PATTERN` | Search process memory for byte pattern |
+| `modules` | List loaded modules with base addresses |
+| `dipcnt on/off/read` | D3D9 DrawIndexedPrimitive call counter |
+| `dipcnt on $DEV_PTR` | Start DIP counter — requires global IDirect3DDevice9* pointer address |
+| `dipcnt callers [N]` | Sample N DIP calls and histogram return addresses |
+| `memwatch start/stop/read` | Memory write watchpoint with backtrace |
+| `vishook on $JMP $ORIG` | Patch jmp trampoline to force visibility for callers above threshold |
+| `vishook off` | Restore original jmp, disable override |
+| `vishook stats` | Show override/passthrough call counts |
+| `analyze $FILE` | Offline analysis of collected .jsonl trace data |
+
+## Game Window Automation (`livetools/gamectl.py`) — no Frida needed
+
+Sends keystrokes and mouse clicks to a game window via Windows **SendInput**. Works standalone — no `attach` session required. All key bindings and sequences are CLI arguments; nothing is hardcoded.
+
+**Why SendInput, not PostMessage/SendMessage**: DirectInput and RawInput games (most DX9-era titles) read raw device state — they ignore `WM_KEYDOWN` posted to the window entirely. `SendInput` injects into the global input stream, which these games do see. The game window must be in the foreground first; `gamectl` handles this automatically via `AttachThreadInput` + `SetForegroundWindow` to bypass the Windows foreground lock.
+
+**Window lookup** — use `--exe` (preferred, matches by process name) or `--window` (title substring fallback):
+
+```
+python -m livetools gamectl --exe <game.exe> info
+python -m livetools gamectl --exe <game.exe> key <KEY>
+python -m livetools gamectl --exe <game.exe> keys "<SEQUENCE>" [--delay-ms N]
+python -m livetools gamectl --exe <game.exe> click <X> <Y>
+python -m livetools gamectl --exe <game.exe> macro --macro-file patches/<Game>/macros.json <NAME>
+python -m livetools gamectl --exe <game.exe> macros --macro-file patches/<Game>/macros.json
+```
+
+Key names: `RETURN`, `ESCAPE`, `SPACE`, `UP`, `DOWN`, `LEFT`, `RIGHT`, `TAB`, `F1`–`F12`, `A`–`Z`, `0`–`9`, `NUMPAD0`–`9`, `SHIFT`, `CTRL`, `ALT`.
+
+Sequence token syntax (used in `keys` and macro `steps`):
+- `KEY_NAME` — keydown + keyup
+- `WAIT:N` — pause N milliseconds
+- `HOLD:KEY_NAME:N` — hold key N ms before keyup
+
+Macro file (`macros.json`) — one file per game, stored in `patches/<GameName>/macros.json`:
+```json
+{
+  "navigate_menu": {
+    "description": "Navigate from title screen into a race",
+    "steps": "RETURN WAIT:1000 DOWN DOWN RETURN WAIT:500 RETURN"
+  },
+  "pause": {
+    "description": "Open pause menu",
+    "steps": "ESCAPE"
+  }
+}
+```
+
+NOTE: Some processes require their window to be focused for traces to capture data.
+
+## D3D9 Frame Trace (`graphics/directx/dx9/tracer/`) — full-frame API capture and analysis
+
+A proxy DLL that intercepts all 119 `IDirect3DDevice9` methods, capturing every call with arguments, backtraces, pointer-followed data (matrices, constants, shader bytecodes), and in-process shader disassembly. Outputs JSONL for offline analysis.
+
+**Architecture**: Python codegen (`d3d9_methods.py`) → C proxy DLL (`src/`) → JSONL → Python analyzer (`analyze.py`).
+
+### Setup and Capture
+
+```
+python -m graphics.directx.dx9.tracer codegen -o d3d9_trace_hooks.inc
+cd graphics/directx/dx9/tracer/src && build.bat
+python -m graphics.directx.dx9.tracer trigger --game-dir <GAME_DIR>
+```
+
+**proxy.ini** settings: `CaptureFrames=N`, `CaptureInit=1`, `Chain.DLL=<wrapper.dll>`.
+
+IMPORTANT: `--game-dir` must point to the directory containing the deployed proxy DLL.
+
+### Key Data Captured
+
+- **Every D3D9 call**: method name, slot, arguments, return value, full backtrace
+- **Shader bytecodes + disassembly**: CTAB with named parameters (e.g. `WorldViewProj`, `FogValue`), register mappings, full instructions
+- **Created object handles**: `CreateVertexDeclaration`/`CreateVertexShader`/`CreatePixelShader` output pointers for handle→bytecode linking
+- **Constant values**: float/int constant registers with source seq# tracking
+- **Matrices**: 4x4 float matrices from `SetTransform`/`MultiplyTransform`
+- **Vertex declarations**: full `D3DVERTEXELEMENT9` arrays with type/usage/stream decoded
+
+### Source Files
+
+| Path | Role |
+|------|------|
+| `graphics/directx/dx9/tracer/cli.py` | CLI entry point (codegen, trigger, analyze) |
+| `graphics/directx/dx9/tracer/analyze.py` | Analysis engine (all `--*` options) |
+| `graphics/directx/dx9/tracer/d3d9_methods.py` | Single source of truth: method signatures, D3D9 enum constants, codegen |
+| `graphics/directx/dx9/tracer/src/` | C proxy DLL source (edit and rebuild for advanced use cases) |
+| `graphics/directx/dx9/tracer/bin/` | Pre-built d3d9.dll + proxy.ini (deploy directly) |
+
+## RTX Remix FFP Scripts (`rtx_remix_tools/dx/dx9_ffp_template/scripts/`)
+
+Static scanners for D3D9 game analysis. Fast first-pass only — always follow up with `retools`/`livetools`.
+
+| Script | What it surfaces |
+|--------|-----------------|
+| `find_d3d_calls.py <game.exe>` | D3D9/D3DX imports and call sites |
+| `find_vs_constants.py <game.exe>` | `SetVertexShaderConstantF` call sites, startRegister and count args |
+| `find_device_calls.py <game.exe>` | Device vtable call patterns and device pointer refs |
+| `find_vtable_calls.py <game.exe>` | ID3DXConstantTable vtable calls (SetMatrix, SetVector, etc.) AND direct D3D9 device vtable calls — useful when engine uses d3dx9 constant tables instead of raw `SetVertexShaderConstantF` |
+| `decode_vtx_decls.py <game.exe> --scan` | Vertex declaration formats (BLENDWEIGHT/BLENDINDICES = skinning, POSITIONT = screen-space) |
+| `scan_d3d_region.py <game.exe> 0xSTART 0xEND` | All D3D9 vtable calls within a specific code region |
+
+## Bundled Radare2 (`tools/radare2-6.1.0-w64/`)
+
+Radare2 6.1.0 is bundled at `tools/radare2-6.1.0-w64/bin/`. The `retools` scripts use it internally via r2pipe — you generally don't invoke it directly. Key executables if needed:
+
+| Binary | Purpose |
+|--------|---------|
+| `radare2.exe` | Interactive RE session (`r2 binary.exe`) |
+| `rabin2.exe` | Binary info: imports, exports, sections, strings (`rabin2 -i binary.exe`) |
+| `rasm2.exe` | Assemble/disassemble single instructions (`rasm2 -a x86 -b 32 "nop"`) |
+| `rafind2.exe` | Search for byte patterns in files |
+| `rahash2.exe` | Hash files or byte ranges |
+| `radiff2.exe` | Binary diff between two files |
+| `rax2.exe` | Number base converter (`rax2 0x401000`) |
+
+### Analysis Commands
+
+All analysis: `python -m graphics.directx.dx9.tracer analyze <JSONL> [OPTIONS]`
+
+| Option | Purpose |
+|--------|---------|
+| `--summary` | Overview: calls per frame/method, backtrace completeness |
+| `--draw-calls` | List every draw call with state deltas |
+| `--callers METHOD` | Caller histogram for a specific method |
+| `--hotpaths` | Frequency-sorted call paths from backtraces |
+| `--state-at SEQ` | Reconstruct full device state at a specific sequence number |
+| `--render-loop` | Detect the render loop entry point from backtraces |
+| `--render-passes` | Group draws by render target, classify pass types |
+| `--matrix-flow` | Track matrix uploads per SetTransform/SetVertexShaderConstantF |
+| `--shader-map` | Disassemble all shaders (CTAB names, register map, instructions) |
+| `--const-provenance` | Compact: for each draw, show which seq# set each named constant |
+| `--const-provenance-draw N` | Detailed: all register values and sources for draw #N |
+| `--classify-draws` | Auto-tag draws (alpha, ztest, fog, fullscreen-quad, etc.) with draw method (DIP/DP/DPUP/DIPUP) and vertex shader breakdown |
+| `--vtx-formats` | Group draws by vertex declaration with element breakdown |
+| `--redundant` | Find redundant state-set calls |
+| `--texture-freq` | Texture binding frequency across all draws |
+| `--rt-graph` | Render target dependency graph (mermaid) |
+| `--diff-draws A B` | State diff between two draw calls |
+| `--diff-frames A B` | Compare two captured frames |
+| `--const-evolution RANGE` | Track how specific registers change across draws (e.g. `vs:c4-c6`, `ps:c0-c3`). Shows per-register stability, 3x3 rotation grouping to identify shared View matrix, translation spread |
+| `--state-snapshot DRAW#` | Complete state dump at a draw index: shaders + CTAB names, constants, vertex decl, textures, render states, transforms, samplers |
+| `--transform-calls` | Analyze SetTransform/SetViewport usage: timing relative to draws, matrix values, whether game uses FFP transforms or shader constants |
+| `--animate-constants` | Cross-frame constant register tracking |
+| `--pipeline-diagram` | Auto-generate mermaid render pipeline diagram |
+| `--resolve-addrs BINARY` | Resolve backtrace addresses to function names via retools |
+| `--filter EXPR` | Filter records by field |
+| `--export-csv FILE` | Export raw records to CSV |
+
+## Decision Guide
+
+- "What does this function do?" → `decompiler.py` (best), then `disasm.py` + `cfg.py`
+- "Decompile with named structs and functions" → `decompiler.py --types`
+- "Who calls this function?" → `xrefs.py` (flat) or `callgraph.py --up` (tree)
+- "What does this function call?" → `funcinfo.py` (list) or `callgraph.py --down` (tree)
+- "Where is this global read/written?" → `datarefs.py`
+- "Where is this string/pointer referenced?" → `datarefs.py --imm`
+- "Find a string and who uses it" → `search.py strings --xrefs`
+- "Where is struct field +0x54 used?" → `structrefs.py`
+- "What does this struct look like?" → `structrefs.py --aggregate`
+- "What C++ class is this vtable?" → `rtti.py vtable`
+- "What type was a caught/thrown exception?" → `rtti.py throwinfo`
+- "Find all instructions using a specific constant" → `search.py insn`
+- "Find a mov-immediate near a struct field access" → `search.py insn --near`
+- "What crashed and why?" → `dumpinfo.py exception` then `dumpinfo.py diagnose --binary` for full pipeline
+- "Where is each thread stuck?" → `dumpinfo.py threads` (add `--verbose` for full register dump)
+- "Walk a crashing thread's call stack" → `dumpinfo.py stack` (add `--depth` for deeper scan)
+- "Find code addresses on a thread's stack by module" → `dumpinfo.py stackscan`
+- "Search dump memory for a string or byte pattern" → `dumpinfo.py memscan`
+- "What memory regions are in the dump?" → `dumpinfo.py memmap`
+- "Extract strings from a crash dump" → `dumpinfo.py strings --pattern`
+- "What exception strings does this binary throw?" → `throwmap.py list`
+- "Which throw site caused this crash?" → `throwmap.py match --dump`
+- "Is this function reached at runtime?" → `livetools trace` or `collect`
+- "What are the actual register values?" → `livetools trace --read` or `bp` + `regs`
+- "How many draw calls happen?" → `livetools dipcnt`
+- "Who writes to this memory address?" → `livetools memwatch`
+- "Force visibility for callers above a threshold address" → `livetools vishook on`
+- "Allocate executable memory in the target process" → `livetools mem alloc`
+- "Send keystrokes or navigate game menus automatically" → `livetools gamectl keys` or `gamectl macro`
+- "What does the game's full render frame look like?" → `dx9tracer analyze --summary` + `--render-passes` + `--pipeline-diagram`
+- "What shaders does the game use and what constants do they need?" → `dx9tracer analyze --shader-map`
+- "Which code set a specific shader constant at draw time?" → `dx9tracer analyze --const-provenance` or `--const-provenance-draw N`
+- "What vertex formats does the game use?" → `dx9tracer analyze --vtx-formats`
+- "What is the full device state at a specific call?" → `dx9tracer analyze --state-at SEQ` or `--state-snapshot DRAW#` (by draw index, with CTAB names)
+- "How do registers change across draws? Which are per-object vs frame-global?" → `dx9tracer analyze --const-evolution vs:c0-c8`
+- "Does the game use SetTransform or only shader constants for matrices?" → `dx9tracer analyze --transform-calls`
+- "How do two draw calls differ?" → `dx9tracer analyze --diff-draws A B`
+- "What is the render target dependency graph?" → `dx9tracer analyze --rt-graph`
+- "Where is the render loop entry point?" → `dx9tracer analyze --render-loop --resolve-addrs <binary>`
+- "Which draw method (DIP/DP) and which shaders account for most draws?" → `dx9tracer analyze --classify-draws`
+- "Which state sets are redundant?" → `dx9tracer analyze --redundant`
+
+## Tool Caveats
+
+### `rtti.py` — MSVC RTTI only
+
+Works exclusively with MSVC-compiled binaries that have RTTI enabled (`/GR`). Will not work with GCC/Clang/MinGW binaries or binaries compiled with `/GR-`.
+
+`throwinfo` input differs by bitness:
+- 64-bit: pass the RVA from the exception record (minidump param[2] minus param[3])
+- 32-bit: pass the absolute VA directly (minidump param[2])
+
+### `funcinfo.py` — call-target heuristic
+
+`find_start()` misses functions only reachable via indirect calls (vtable dispatch, callbacks). If it returns a wrong function start, use `disasm.py` and look for padding/prologues manually.
+
+### `datarefs.py` / `search.py strings --xrefs` — addressing modes
+
+If a reference isn't found, the address might be computed at runtime. Try `search.py pattern` with the address bytes, or use `livetools memwatch`.
+
+### `throwmap.py` — x86/x64 MSVC only
+
+Finds throw sites by scanning for `__CxxThrowException` IAT calls and resolving the string argument. Works on MSVC binaries only. The `match` subcommand cross-references a minidump's exception record against the throw map to pinpoint the exact throw site — more precise than `dumpinfo.py exception` alone when the exception type name isn't enough.
+
+## Project Workspace
+
+Use `patches/<project_name>/` (git-ignored) for all project-specific artifacts:
+- Knowledge base files (`kb.h`)
+- One-off analysis scripts
+- ASI patch specs and builds
+- Notes, logs, collected trace data
+
+## Knowledge Base
+
+When reverse engineering a binary, maintain a knowledge base file (`.h`) at `patches/<project>/kb.h`.
+
+**Format:**
+```c
+// C type definitions (structs, enums, typedefs) — no prefix
+struct Foo { int x; float y; };
+enum Mode { MODE_A=0, MODE_B=1 };
+
+// Function signatures at addresses — @ prefix
+@ 0x401000 void __cdecl ProcessInput(int key);
+@ 0x402000 float __thiscall Object_GetValue(Object* this);
+
+// Global variables at addresses — $ prefix
+$ 0x7C5548 Object* g_mainObject
+$ 0x7C554C Flags g_renderFlags
+```
+
+When to update the KB:
+- Identified a function's purpose → add `@ 0xADDR` with name and signature
+- Reconstructed a struct → add the struct definition
+- Identified a global variable → add `$ 0xADDR` with name and type
+- Identified magic constants → define an enum with named values
+- `rtti.py` revealed a class name → use it in struct/function names
+
+Always pass `--types <kb_file>` when using `decompiler.py` so accumulated knowledge improves every decompilation.

--- a/README.md
+++ b/README.md
@@ -24,31 +24,7 @@ python -m venv .venv
 pip install -r requirements.txt
 ```
 
-## How it works
-
-The project ships with agent instructions tailored to each supported environment:
-
-- **Cursor** — `.cursor/rules/`
-- **Copilot** — `.github/copilot-instructions.md`
-- **Claude Code** — `CLAUDE.md`
-- **Kiro** — `.kiro/steering/` (auto-loaded context) and `.kiro/powers/` (on-demand skills)
-
-Each teaches the agent the full tool catalog -- which tool to reach for, when, and why. The agent picks the right tool automatically based on your question.
-
-### Kiro steering files
-
-| File | Purpose |
-|------|---------|
-| `.kiro/steering/tool-catalog.md` | Complete tool reference — loaded automatically in every session |
-| `.kiro/steering/engineering-standards.md` | Code quality and comment standards |
-| `.kiro/steering/dx9-ffp-port.md` | RTX Remix FFP porting workflow — loaded when working on proxy/patch files |
-
-### Kiro powers (on-demand skills)
-
-| Power | Purpose |
-|-------|---------|
-| `.kiro/powers/dx9-ffp-port/` | Deep knowledge base for DX9 fixed-function pipeline porting |
-| `.kiro/powers/dynamic-analysis/` | Frida-based dynamic analysis patterns and workflows |
+## Tools
 
 **Static analysis** (`retools/`) works directly on PE files on disk: disassembly, decompilation, cross-references, call graphs, vtable analysis, byte pattern search, and more.
 
@@ -61,6 +37,40 @@ python -m livetools gamectl --exe game.exe info
 python -m livetools gamectl --exe game.exe keys "DOWN DOWN RETURN"
 python -m livetools gamectl --exe game.exe macro --macro-file patches/MyGame/macros.json navigate_menu
 ```
+
+**D3D9 frame tracer** (`graphics/directx/dx9/tracer/`) captures every `IDirect3DDevice9` call with arguments, backtraces, shader bytecodes, and matrix data. Outputs JSONL for offline analysis.
+
+**RTX Remix FFP template** (`rtx_remix_tools/dx/dx9_ffp_template/`) is a D3D9 proxy DLL that converts shader-based games to fixed-function pipeline for RTX Remix compatibility.
+
+## How it works
+
+The project ships with agent instructions tailored to each supported environment:
+
+| Tool | Instructions |
+|------|-------------|
+| Cursor | `.cursor/rules/` |
+| Copilot | `.github/copilot-instructions.md` |
+| Claude Code | `CLAUDE.md` |
+| Kiro | `.kiro/steering/` + `.kiro/powers/` |
+
+Each teaches the agent the full tool catalog — which tool to reach for, when, and why. The agent picks the right tool automatically based on your question.
+
+### Kiro
+
+Kiro loads context automatically via steering files and exposes deep skill knowledge via powers:
+
+| Steering file | Loaded | Purpose |
+|---------------|--------|---------|
+| `tool-catalog.md` | Always | Complete reference for all tools |
+| `engineering-standards.md` | Always | Code quality and comment standards |
+| `dx9-ffp-port.md` | On proxy/patch files | RTX Remix FFP porting workflow |
+
+| Power | Purpose |
+|-------|---------|
+| `dx9-ffp-port` | DX9 fixed-function pipeline porting knowledge base |
+| `dynamic-analysis` | Frida-based dynamic analysis patterns and workflows |
+
+Kiro also has agent hooks that enforce the workflow: research the game/API online and write a spec before touching code, verify fixes actually work after the agent stops, and keep the KB updated with game-specific findings.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -55,23 +55,6 @@ The project ships with agent instructions tailored to each supported environment
 
 Each teaches the agent the full tool catalog — which tool to reach for, when, and why. The agent picks the right tool automatically based on your question.
 
-### Kiro
-
-Kiro loads context automatically via steering files and exposes deep skill knowledge via powers:
-
-| Steering file | Loaded | Purpose |
-|---------------|--------|---------|
-| `tool-catalog.md` | Always | Complete reference for all tools |
-| `engineering-standards.md` | Always | Code quality and comment standards |
-| `dx9-ffp-port.md` | On proxy/patch files | RTX Remix FFP porting workflow |
-
-| Power | Purpose |
-|-------|---------|
-| `dx9-ffp-port` | DX9 fixed-function pipeline porting knowledge base |
-| `dynamic-analysis` | Frida-based dynamic analysis patterns and workflows |
-
-Kiro also has agent hooks that enforce the workflow: research the game/API online and write a spec before touching code, verify fixes actually work after the agent stops, and keep the KB updated with game-specific findings.
-
 ## Usage
 
 Open this directory in your agentic coding tool and describe what you're after:

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ No reverse engineering experience required -- just good prompting. Although some
   - [Cursor IDE](https://cursor.sh)
   - [VSCode](https://code.visualstudio.com/) + [Copilot](https://github.com/features/copilot)
   - [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+  - [Kiro](https://kiro.dev)
 - Python 3.10+
 - Visual Studio 2022+ with C++ Desktop workload (only needed to build ASI patches)
 
@@ -30,12 +31,36 @@ The project ships with agent instructions tailored to each supported environment
 - **Cursor** — `.cursor/rules/`
 - **Copilot** — `.github/copilot-instructions.md`
 - **Claude Code** — `CLAUDE.md`
+- **Kiro** — `.kiro/steering/` (auto-loaded context) and `.kiro/powers/` (on-demand skills)
 
 Each teaches the agent the full tool catalog -- which tool to reach for, when, and why. The agent picks the right tool automatically based on your question.
+
+### Kiro steering files
+
+| File | Purpose |
+|------|---------|
+| `.kiro/steering/tool-catalog.md` | Complete tool reference — loaded automatically in every session |
+| `.kiro/steering/engineering-standards.md` | Code quality and comment standards |
+| `.kiro/steering/dx9-ffp-port.md` | RTX Remix FFP porting workflow — loaded when working on proxy/patch files |
+
+### Kiro powers (on-demand skills)
+
+| Power | Purpose |
+|-------|---------|
+| `.kiro/powers/dx9-ffp-port/` | Deep knowledge base for DX9 fixed-function pipeline porting |
+| `.kiro/powers/dynamic-analysis/` | Frida-based dynamic analysis patterns and workflows |
 
 **Static analysis** (`retools/`) works directly on PE files on disk: disassembly, decompilation, cross-references, call graphs, vtable analysis, byte pattern search, and more.
 
 **Dynamic analysis** (`livetools/`) attaches to a running process via Frida: breakpoints, register/memory inspection, function tracing, instruction-level stepping, and live memory patching.
+
+**Game window automation** (`livetools/gamectl.py`) sends keystrokes and mouse clicks to a game window without Frida. Uses `SendInput` with `AttachThreadInput` focus management — works with DirectInput/RawInput games that ignore `PostMessage`. Target by process exe name:
+
+```bash
+python -m livetools gamectl --exe game.exe info
+python -m livetools gamectl --exe game.exe keys "DOWN DOWN RETURN"
+python -m livetools gamectl --exe game.exe macro --macro-file patches/MyGame/macros.json navigate_menu
+```
 
 ## Usage
 

--- a/livetools/__main__.py
+++ b/livetools/__main__.py
@@ -593,6 +593,64 @@ def cmd_memwatch(args: argparse.Namespace) -> None:
         print("Usage: python -m livetools memwatch [start|stop|read]")
 
 
+# ── gamectl command ───────────────────────────────────────────────────────
+
+def cmd_gamectl(args: argparse.Namespace) -> None:
+    from . import gamectl as gc
+    action = args.gc_action
+
+    hwnd, err = gc.resolve_hwnd(getattr(args, "exe", None),
+                                getattr(args, "window", None))
+    if action == "info":
+        # info doesn't need a valid hwnd to report the error clearly
+        if not hwnd:
+            print(f"[error] {err}"); return
+        info = gc.get_window_info(hwnd)
+        print(f"hwnd:  {info['hwnd']}")
+        print(f"title: {info['title']}")
+        print(f"pid:   {info['pid']}")
+        print(f"tid:   {info['tid']}")
+        return
+
+    if not hwnd:
+        print(f"[error] {err}"); return
+
+    if action == "key":
+        focused = gc.focus_hwnd(hwnd)
+        r = gc.send_key(args.key_name, hold_ms=args.hold_ms)
+        print(f"focused={focused} {r}")
+
+    elif action == "keys":
+        r = gc.send_keys(hwnd, args.sequence, delay_ms=args.delay_ms)
+        print(f"focused={r['focused']} sent={r['count']} ok={r['ok']}")
+        for a in r["actions"]:
+            if not a.get("ok", True):
+                print(f"  [error] {a}")
+
+    elif action == "click":
+        r = gc.click_at(hwnd, args.x, args.y)
+        print(r)
+
+    elif action == "macro":
+        macros = gc.load_macros(args.macro_file)
+        r = gc.run_macro(hwnd, args.macro_name, macros, delay_ms=args.delay_ms)
+        if r["ok"]:
+            print(f"Macro '{args.macro_name}' done. "
+                  f"{r['steps_result']['count']} actions sent.")
+        else:
+            print(f"[error] {r.get('error', r)}")
+
+    elif action == "macros":
+        macros = gc.load_macros(args.macro_file)
+        print(f"Macros in {args.macro_file}:")
+        for name, defn in sorted(macros.items()):
+            print(f"  {name:<24s}  {defn.get('description', '')}")
+            print(f"    steps: {defn.get('steps', '')}")
+
+    else:
+        print("Usage: python -m livetools gamectl [info|key|keys|click|macro|macros]")
+
+
 # ── argument parser ────────────────────────────────────────────────────────
 
 def build_parser() -> argparse.ArgumentParser:
@@ -946,6 +1004,66 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--export-csv", default=None,
         help="Export filtered/grouped data as CSV to file")
 
+    # -- gamectl --
+    sp = sub.add_parser("gamectl",
+        help="Send keystrokes/mouse clicks directly to a game window (no Frida, no focus needed)",
+        description=(
+            "Posts WM_KEYDOWN/WM_KEYUP directly to the target window handle.\n"
+            "No focus stealing — works even when the game is in the background.\n\n"
+            "Window lookup (pick one):\n"
+            "  --exe game.exe      find window by process exe name (recommended)\n"
+            "  --window <hint>     find window by title substring\n\n"
+            "Key names: RETURN, ESCAPE, SPACE, UP, DOWN, LEFT, RIGHT,\n"
+            "           TAB, F1-F12, A-Z, 0-9, NUMPAD0-9, SHIFT, CTRL, ALT\n\n"
+            "Sequence token syntax:\n"
+            "  KEY_NAME          — keydown + keyup\n"
+            "  WAIT:N            — pause N milliseconds\n"
+            "  HOLD:KEY_NAME:N   — hold key N ms before keyup\n\n"
+            "Examples:\n"
+            "  python -m livetools gamectl --exe revolt_xbox.exe info\n"
+            "  python -m livetools gamectl --exe revolt_xbox.exe key RETURN\n"
+            "  python -m livetools gamectl --exe revolt_xbox.exe keys \"DOWN DOWN RETURN\"\n"
+            "  python -m livetools gamectl --exe revolt_xbox.exe keys "
+            "\"RETURN WAIT:1000 RETURN WAIT:1000 RETURN\" --delay-ms 0\n"
+            "  python -m livetools gamectl --exe revolt_xbox.exe click 400 300\n"
+            "  python -m livetools gamectl --exe revolt_xbox.exe macro "
+            "--macro-file patches/revolt/macros.json navigate_menu"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    sp.add_argument("--exe", "-e", default=None,
+        help="Target process exe name (e.g. revolt_xbox.exe) — preferred over --window")
+    sp.add_argument("--window", "-w", default=None,
+        help="Window title substring fallback (case-insensitive)")
+    gc_sub = sp.add_subparsers(dest="gc_action")
+
+    gc_sub.add_parser("info", help="Show hwnd, title, pid for the matched window")
+
+    gc_key = gc_sub.add_parser("key", help="Send a single key press")
+    gc_key.add_argument("key_name", help="Key name (e.g. RETURN, UP, F5, A)")
+    gc_key.add_argument("--hold-ms", type=int, default=50,
+        help="Hold duration in ms (default: 50)")
+
+    gc_keys = gc_sub.add_parser("keys", help="Send a space-separated key sequence")
+    gc_keys.add_argument("sequence",
+        help='e.g. "DOWN DOWN RETURN" or "RETURN WAIT:1000 RETURN"')
+    gc_keys.add_argument("--delay-ms", type=int, default=200,
+        help="Delay between keys in ms (default: 200)")
+
+    gc_click = gc_sub.add_parser("click", help="Post left-click at client-area coordinates")
+    gc_click.add_argument("x", type=int, help="Client X coordinate")
+    gc_click.add_argument("y", type=int, help="Client Y coordinate")
+
+    gc_macro = gc_sub.add_parser("macro", help="Run a named macro from a JSON file")
+    gc_macro.add_argument("macro_name", help="Macro name to execute")
+    gc_macro.add_argument("--macro-file", default="macros.json",
+        help="Path to macro JSON file (default: macros.json)")
+    gc_macro.add_argument("--delay-ms", type=int, default=200,
+        help="Delay between keys in ms (default: 200)")
+
+    gc_macros = gc_sub.add_parser("macros", help="List all macros in a JSON file")
+    gc_macros.add_argument("--macro-file", default="macros.json",
+        help="Path to macro JSON file (default: macros.json)")
+
     return p
 
 
@@ -988,6 +1106,7 @@ def main() -> None:
         "dipcnt": cmd_dipcnt,
         "memwatch": cmd_memwatch,
         "analyze": cmd_analyze,
+        "gamectl": cmd_gamectl,
     }
 
     handler = dispatch.get(args.command)

--- a/livetools/gamectl.py
+++ b/livetools/gamectl.py
@@ -1,0 +1,396 @@
+"""Game window input automation via SendInput with proper focus management.
+
+Re-Volt and most older DX9/DirectInput games read raw device state — they
+ignore WM_KEYDOWN/PostMessage entirely. SendInput is required, but the game
+window must be in the foreground first.
+
+Focus strategy: attach our thread to the game's input queue via
+AttachThreadInput, then SetForegroundWindow. This bypasses the Windows
+foreground-lock that normally blocks background processes from stealing focus.
+
+Window lookup supports two modes:
+  --exe    <exe_name>     find window by process exe name (recommended)
+  --window <title_hint>   find window by title substring fallback
+
+Usage (CLI):
+    python -m livetools gamectl --exe revolt_xbox.exe info
+    python -m livetools gamectl --exe revolt_xbox.exe key RETURN
+    python -m livetools gamectl --exe revolt_xbox.exe keys "DOWN DOWN RETURN"
+    python -m livetools gamectl --exe revolt_xbox.exe keys "RETURN WAIT:1000 RETURN" --delay-ms 0
+    python -m livetools gamectl --exe revolt_xbox.exe click 400 300
+    python -m livetools gamectl --exe revolt_xbox.exe macro --macro-file patches/revolt/macros.json navigate_menu
+    python -m livetools gamectl --exe revolt_xbox.exe macros --macro-file patches/revolt/macros.json
+
+Usage (library):
+    from livetools.gamectl import find_hwnd_by_exe, focus_hwnd, send_key, send_keys
+    hwnd = find_hwnd_by_exe("revolt_xbox.exe")
+    focus_hwnd(hwnd)
+    send_key("RETURN")
+    send_keys("DOWN DOWN RETURN", delay_ms=200)
+
+Macro file format (JSON) — store at patches/<GameName>/macros.json:
+    {
+      "navigate_menu": {
+        "description": "Navigate from title screen into a race",
+        "steps": "RETURN WAIT:1000 DOWN DOWN RETURN WAIT:500 RETURN"
+      }
+    }
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.wintypes as wt
+import json
+import time
+from pathlib import Path
+
+# ── Win32 constants ────────────────────────────────────────────────────────
+
+INPUT_KEYBOARD       = 1
+INPUT_MOUSE          = 0
+KEYEVENTF_KEYUP      = 0x0002
+MOUSEEVENTF_LEFTDOWN = 0x0002
+MOUSEEVENTF_LEFTUP   = 0x0004
+SW_RESTORE           = 9
+SW_SHOW              = 5
+GW_OWNER             = 4
+TH32CS_SNAPPROCESS   = 0x00000002
+
+user32   = ctypes.windll.user32
+kernel32 = ctypes.windll.kernel32
+
+# ── Virtual key map ────────────────────────────────────────────────────────
+
+VK_MAP: dict[str, int] = {
+    "RETURN": 0x0D, "ENTER": 0x0D,
+    "ESCAPE": 0x1B, "ESC": 0x1B,
+    "SPACE": 0x20,
+    "UP": 0x26, "DOWN": 0x28, "LEFT": 0x25, "RIGHT": 0x27,
+    "TAB": 0x09, "BACKSPACE": 0x08, "DELETE": 0x2E,
+    "HOME": 0x24, "END": 0x23, "PAGEUP": 0x21, "PAGEDOWN": 0x22,
+    "F1": 0x70, "F2": 0x71, "F3": 0x72,  "F4": 0x73,
+    "F5": 0x74, "F6": 0x75, "F7": 0x76,  "F8": 0x77,
+    "F9": 0x78, "F10": 0x79, "F11": 0x7A, "F12": 0x7B,
+    "SHIFT": 0x10, "CTRL": 0x11, "ALT": 0x12,
+    **{c: 0x41 + i for i, c in enumerate("ABCDEFGHIJKLMNOPQRSTUVWXYZ")},
+    **{str(d): 0x30 + d for d in range(10)},
+    "NUMPAD0": 0x60, "NUMPAD1": 0x61, "NUMPAD2": 0x62, "NUMPAD3": 0x63,
+    "NUMPAD4": 0x64, "NUMPAD5": 0x65, "NUMPAD6": 0x66, "NUMPAD7": 0x67,
+    "NUMPAD8": 0x68, "NUMPAD9": 0x69,
+}
+
+# ── SendInput structures ───────────────────────────────────────────────────
+
+class KEYBDINPUT(ctypes.Structure):
+    _fields_ = [
+        ("wVk",         wt.WORD),
+        ("wScan",       wt.WORD),
+        ("dwFlags",     wt.DWORD),
+        ("time",        wt.DWORD),
+        ("dwExtraInfo", ctypes.POINTER(ctypes.c_ulong)),
+    ]
+
+class MOUSEINPUT(ctypes.Structure):
+    _fields_ = [
+        ("dx",          wt.LONG),
+        ("dy",          wt.LONG),
+        ("mouseData",   wt.DWORD),
+        ("dwFlags",     wt.DWORD),
+        ("time",        wt.DWORD),
+        ("dwExtraInfo", ctypes.POINTER(ctypes.c_ulong)),
+    ]
+
+class _INPUT_UNION(ctypes.Union):
+    _fields_ = [("ki", KEYBDINPUT), ("mi", MOUSEINPUT)]
+
+class INPUT(ctypes.Structure):
+    _fields_ = [("type", wt.DWORD), ("union", _INPUT_UNION)]
+
+WNDENUMPROC = ctypes.WINFUNCTYPE(wt.BOOL, wt.HWND, wt.LPARAM)
+
+class PROCESSENTRY32(ctypes.Structure):
+    _fields_ = [
+        ("dwSize",              wt.DWORD),
+        ("cntUsage",            wt.DWORD),
+        ("th32ProcessID",       wt.DWORD),
+        ("th32DefaultHeapID",   ctypes.POINTER(ctypes.c_ulong)),
+        ("th32ModuleID",        wt.DWORD),
+        ("cntThreads",          wt.DWORD),
+        ("th32ParentProcessID", wt.DWORD),
+        ("pcPriClassBase",      ctypes.c_long),
+        ("dwFlags",             wt.DWORD),
+        ("szExeFile",           ctypes.c_char * 260),
+    ]
+
+
+def _find_pid(exe_name: str) -> int | None:
+    """Return the PID of the first process whose exe matches exe_name."""
+    snap = kernel32.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
+    if snap == ctypes.c_void_p(-1).value:
+        return None
+    entry = PROCESSENTRY32()
+    entry.dwSize = ctypes.sizeof(PROCESSENTRY32)
+    try:
+        if not kernel32.Process32First(snap, ctypes.byref(entry)):
+            return None
+        while True:
+            name = entry.szExeFile.decode("utf-8", errors="replace")
+            if name.lower() == exe_name.lower():
+                return entry.th32ProcessID
+            if not kernel32.Process32Next(snap, ctypes.byref(entry)):
+                break
+    finally:
+        kernel32.CloseHandle(snap)
+    return None
+
+# ── Window lookup ──────────────────────────────────────────────────────────
+
+WNDENUMPROC = ctypes.WINFUNCTYPE(wt.BOOL, wt.HWND, wt.LPARAM)
+
+
+def find_hwnd_by_exe(exe_name: str) -> int | None:
+    """Find the main visible window of a process by its exe filename.
+
+    Args:
+        exe_name: Process exe name, e.g. "revolt_xbox.exe"
+
+    Returns:
+        Window handle (int) or None if not found.
+    """
+    pid = _find_pid(exe_name)
+    if pid is None:
+        return None
+    result: list[int] = []
+
+    @WNDENUMPROC
+    def _cb(hwnd: int, _: int) -> bool:
+        if not user32.IsWindowVisible(hwnd):
+            return True
+        if user32.GetWindow(hwnd, GW_OWNER) != 0:
+            return True
+        proc_id = wt.DWORD(0)
+        user32.GetWindowThreadProcessId(hwnd, ctypes.byref(proc_id))
+        if proc_id.value == pid:
+            result.append(hwnd)
+        return True
+
+    user32.EnumWindows(_cb, 0)
+    return result[0] if result else None
+
+
+def find_hwnd_by_title(title_hint: str) -> int | None:
+    """Find the first visible top-level window whose title contains title_hint."""
+    result: list[int] = []
+
+    @WNDENUMPROC
+    def _cb(hwnd: int, _: int) -> bool:
+        if not user32.IsWindowVisible(hwnd):
+            return True
+        if user32.GetWindow(hwnd, GW_OWNER) != 0:
+            return True
+        buf = ctypes.create_unicode_buffer(256)
+        user32.GetWindowTextW(hwnd, buf, 256)
+        if buf.value and title_hint.lower() in buf.value.lower():
+            result.append(hwnd)
+        return True
+
+    user32.EnumWindows(_cb, 0)
+    return result[0] if result else None
+
+
+def resolve_hwnd(exe: str | None, window: str | None) -> tuple[int | None, str]:
+    """Resolve hwnd from --exe or --window, return (hwnd, error_msg)."""
+    if exe:
+        hwnd = find_hwnd_by_exe(exe)
+        if not hwnd:
+            return None, f"No window found for process '{exe}'"
+        return hwnd, ""
+    if window:
+        hwnd = find_hwnd_by_title(window)
+        if not hwnd:
+            return None, f"No window found matching title '{window}'"
+        return hwnd, ""
+    return None, "Provide --exe <game.exe> or --window <title>"
+
+
+def get_window_info(hwnd: int) -> dict:
+    """Return title and process info for a hwnd."""
+    buf = ctypes.create_unicode_buffer(256)
+    user32.GetWindowTextW(hwnd, buf, 256)
+    pid = wt.DWORD(0)
+    tid = user32.GetWindowThreadProcessId(hwnd, ctypes.byref(pid))
+    return {"hwnd": hwnd, "title": buf.value, "pid": pid.value, "tid": tid}
+
+# ── Focus management ───────────────────────────────────────────────────────
+
+def focus_hwnd(hwnd: int) -> bool:
+    """Force hwnd to the foreground using AttachThreadInput.
+
+    DirectInput games only process keys when their window is the foreground
+    window. This attaches our thread to the game's input queue so
+    SetForegroundWindow is not blocked by the Windows foreground lock.
+
+    Returns True if the window is in the foreground after the call.
+    """
+    if user32.IsIconic(hwnd):
+        user32.ShowWindow(hwnd, SW_RESTORE)
+        time.sleep(0.3)
+
+    my_tid  = kernel32.GetCurrentThreadId()
+    fg_hwnd = user32.GetForegroundWindow()
+    fg_tid  = user32.GetWindowThreadProcessId(fg_hwnd, None)
+
+    if fg_tid and fg_tid != my_tid:
+        user32.AttachThreadInput(my_tid, fg_tid, True)
+        user32.BringWindowToTop(hwnd)
+        user32.SetForegroundWindow(hwnd)
+        user32.AttachThreadInput(my_tid, fg_tid, False)
+    else:
+        user32.SetForegroundWindow(hwnd)
+
+    time.sleep(0.15)
+    return user32.GetForegroundWindow() == hwnd
+
+# ── SendInput keyboard ─────────────────────────────────────────────────────
+
+def _make_key_input(vk: int, up: bool = False) -> INPUT:
+    inp = INPUT()
+    inp.type = INPUT_KEYBOARD
+    inp.union.ki.wVk   = vk
+    inp.union.ki.wScan = user32.MapVirtualKeyW(vk, 0)
+    inp.union.ki.dwFlags = KEYEVENTF_KEYUP if up else 0
+    inp.union.ki.time = 0
+    inp.union.ki.dwExtraInfo = None
+    return inp
+
+
+def send_key(key_name: str, hold_ms: int = 50) -> dict:
+    """Send a single key press via SendInput (game must be foreground).
+
+    Args:
+        key_name: Key name from VK_MAP (e.g. "RETURN", "UP", "A", "F5").
+        hold_ms:  Delay between keydown and keyup in milliseconds.
+
+    Returns:
+        dict with ok, key, vk
+    """
+    vk = VK_MAP.get(key_name.upper())
+    if vk is None:
+        return {"ok": False, "error": f"Unknown key: '{key_name}'. "
+                f"Valid: {', '.join(sorted(VK_MAP))}"}
+    dn = (INPUT * 1)(_make_key_input(vk, up=False))
+    user32.SendInput(1, dn, ctypes.sizeof(INPUT))
+    time.sleep(hold_ms / 1000.0)
+    up = (INPUT * 1)(_make_key_input(vk, up=True))
+    user32.SendInput(1, up, ctypes.sizeof(INPUT))
+    return {"ok": True, "key": key_name, "vk": hex(vk)}
+
+
+def send_keys(hwnd: int, sequence: str, delay_ms: int = 200) -> dict:
+    """Focus hwnd then send a space-separated key sequence via SendInput.
+
+    Token syntax:
+        KEY_NAME          — keydown + keyup
+        WAIT:N            — pause N milliseconds
+        HOLD:KEY_NAME:N   — hold key N ms before keyup
+
+    Args:
+        hwnd:      Target window handle (will be focused before sending).
+        sequence:  Space-separated token string.
+        delay_ms:  Default inter-key delay in milliseconds.
+
+    Returns:
+        dict with ok, count, actions
+    """
+    focused = focus_hwnd(hwnd)
+    if not focused:
+        # Still try — some games accept input even if focus check is unreliable
+        pass
+
+    actions: list[dict] = []
+    for token in sequence.strip().split():
+        upper = token.upper()
+        if upper.startswith("WAIT:"):
+            ms = int(token.split(":")[1])
+            time.sleep(ms / 1000.0)
+            actions.append({"action": "wait", "ms": ms})
+        elif upper.startswith("HOLD:"):
+            parts = token.split(":")
+            key = parts[1]
+            ms  = int(parts[2]) if len(parts) > 2 else 500
+            r   = send_key(key, hold_ms=ms)
+            actions.append({**r, "action": "hold", "hold_ms": ms})
+            time.sleep(delay_ms / 1000.0)
+        else:
+            r = send_key(token)
+            actions.append(r)
+            time.sleep(delay_ms / 1000.0)
+    return {"ok": True, "focused": focused, "count": len(actions), "actions": actions}
+
+# ── Mouse input ────────────────────────────────────────────────────────────
+
+def click_at(hwnd: int, x: int, y: int) -> dict:
+    """Focus hwnd then left-click at client-area coordinates via SendInput.
+
+    Args:
+        hwnd: Target window handle.
+        x, y: Client-area coordinates.
+
+    Returns:
+        dict with ok, screen_x, screen_y
+    """
+    focus_hwnd(hwnd)
+    pt = wt.POINT(x, y)
+    user32.ClientToScreen(hwnd, ctypes.byref(pt))
+    user32.SetCursorPos(pt.x, pt.y)
+    time.sleep(0.05)
+
+    dn = INPUT(); dn.type = INPUT_MOUSE; dn.union.mi.dwFlags = MOUSEEVENTF_LEFTDOWN
+    up = INPUT(); up.type = INPUT_MOUSE; up.union.mi.dwFlags = MOUSEEVENTF_LEFTUP
+    arr = (INPUT * 2)(dn, up)
+    user32.SendInput(2, arr, ctypes.sizeof(INPUT))
+    return {"ok": True, "screen_x": pt.x, "screen_y": pt.y, "client_x": x, "client_y": y}
+
+# ── Macro support ──────────────────────────────────────────────────────────
+
+def load_macros(path: str | Path) -> dict[str, dict]:
+    """Load a macro JSON file.
+
+    Args:
+        path: Path to JSON file mapping name -> {description, steps}.
+
+    Returns:
+        dict of macro definitions.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Macro file not found: {p}")
+    data = json.loads(p.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("Macro file must be a JSON object")
+    return data
+
+
+def run_macro(hwnd: int, name: str, macros: dict[str, dict],
+              delay_ms: int = 200) -> dict:
+    """Focus hwnd and execute a named macro.
+
+    Args:
+        hwnd:      Target window handle.
+        name:      Macro name key.
+        macros:    Loaded macro definitions.
+        delay_ms:  Inter-key delay in milliseconds.
+
+    Returns:
+        dict with ok, macro, steps_result
+    """
+    if name not in macros:
+        return {"ok": False,
+                "error": f"Macro '{name}' not found. "
+                         f"Available: {', '.join(sorted(macros))}"}
+    steps = macros[name].get("steps", "")
+    if not steps:
+        return {"ok": False, "error": f"Macro '{name}' has no steps"}
+    result = send_keys(hwnd, steps, delay_ms=delay_ms)
+    return {"ok": result["ok"], "macro": name, "steps_result": result}


### PR DESCRIPTION
Full sync pass across all 4 IDE configs (Cursor, Claude Code, Copilot, Kiro) using 
tool-catalog.mdc
 as the canonical reference.

What changed:

Aligned tool descriptions, caveats, Decision Guide, and RTX Remix section structure across all 4 IDEs so nothing is missing or extra
Removed all specific game names — using SomeGame/game.exe as generic placeholders
Fixed duplicates (dynamic-analysis skills, Decision Guide entries, Kiro-only standalone section)
Expanded shorter caveats (funcinfo, datarefs, rtti, throwmap) so every IDE gets the same detail level
Restructured CLAUDE.md RTX Remix section to match Cursor (moved implementation-specific content to skill file where it belongs)
Each IDE still references its own mechanism for loading dx9-ffp-port detail