### PR TITLE
pyghidra dual-backend decompilation integration

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,6 +7,7 @@
 - `context.py assemble` / `postprocess` (context gathering, <5s)
 - `readmem.py` (single typed read from PE, <5s)
 - `asi_patcher.py build` (build step, not analysis)
+- `pyghidra_backend.py status` (project existence check, <1s)
 
 If you're about to run a second retools command in the same turn, you should have delegated.
 

--- a/.claude/agents/static-analyzer.md
+++ b/.claude/agents/static-analyzer.md
@@ -16,24 +16,51 @@ On first invocation, read the full tool catalog at `.claude/rules/tool-catalog.m
 
 Before any analysis, run these checks in order:
 
-**1. Signature DB**: If `retools/data/signatures.db` does not exist, pull it first:
+**1. Verify install**: Run `python verify_install.py` on first invocation. If pyghidra/Ghidra/Java show as WARN, run `python verify_install.py --setup` to auto-download JDK 21 + Ghidra + pyghidra. One-time ~600MB download.
+
+**2. Signature DB**: If `retools/data/signatures.db` does not exist, pull it first:
 ```bash
 test -f retools/data/signatures.db || python retools/sigdb.py pull
 ```
 
-**2. Bootstrap**: Check if the project KB needs bootstrapping:
+**3. Bootstrap**: Check if the project KB needs bootstrapping:
 ```bash
 grep -cE '^[@$]|^struct |^enum ' patches/<project>/kb.h 2>/dev/null || echo 0
 ```
 If the count is under 50 (or the file doesn't exist), run `python -m retools.bootstrap <binary> --project <Project>` first. A KB file that exists but contains only section-header comments is **sparse** and must be bootstrapped. Do not skip bootstrap just because the file exists.
 
+**4. Ghidra project**: Check if a Ghidra project exists for the binary:
+```bash
+python retools/pyghidra_backend.py status <binary> --project patches/<Project>
+```
+If "Not analyzed", run `python retools/pyghidra_backend.py analyze <binary> --project patches/<Project>`. Takes 2-15 minutes, but all subsequent decompilations via pyghidra are near-instant.
+
 ## Running Tools
 
-Run all tools from the repo root using `python -m retools.<module>` syntax:
+Run all tools from the repo root. Use `python -m retools.<module>` or `python retools/<module>.py` syntax:
 
+### Decompilation (two backends)
+
+**pyghidra (preferred when Ghidra project exists)** — better MSVC type propagation, library call resolution, larger function scope detection:
 ```
-python -m retools.decompiler binary.exe 0x401000
+python retools/pyghidra_backend.py decompile binary.exe 0x401000 --project patches/proj
+```
+
+**r2ghidra (fast fallback)** — better `__thiscall` on small functions, no JVM startup:
+```
 python -m retools.decompiler binary.exe 0x401000 --types patches/proj/kb.h
+python -m retools.decompiler binary.exe 0x401000 --types patches/proj/kb.h --backend pdg
+```
+
+**Auto mode (tries pyghidra first, falls back to r2ghidra)**:
+```
+python -m retools.decompiler binary.exe 0x401000 --types patches/proj/kb.h --project patches/proj
+```
+
+When told to use a specific backend, use it. Otherwise prefer auto mode with both `--types` and `--project`.
+
+### Other tools
+```
 python -m retools.search binary.exe strings -f "error" --xrefs
 python -m retools.xrefs binary.exe 0x401000 -t call
 python -m retools.callgraph binary.exe 0x401000 --up 3
@@ -41,14 +68,15 @@ python -m retools.structrefs binary.exe --aggregate --fn 0x401000 --base esi
 python -m retools.dumpinfo crash.dmp diagnose --binary d3d9.dll
 python -m retools.throwmap d3d9.dll match --dump crash.dmp
 python -m retools.bootstrap binary.exe --project MyGame
-python -m retools.bootstrap binary.exe --project MyGame --db retools/data/signatures.db
 python -m retools.sigdb scan binary.exe --db retools/data/signatures.db
 python -m retools.sigdb identify binary.exe 0x401000 --db retools/data/signatures.db
 python -m retools.sigdb fingerprint binary.exe
 python -m retools.context assemble binary.exe 0x401000 --project MyGame
+python retools/pyghidra_backend.py analyze binary.exe --project patches/MyGame
+python retools/pyghidra_backend.py status binary.exe --project patches/MyGame
 ```
 
-If `retools/data/signatures.db` is missing, run `python -m retools.sigdb pull` to download it before using `sigdb scan` or `sigdb build`.
+If `retools/data/signatures.db` is missing, run `python -m retools.sigdb pull` to download it.
 
 Collect MORE information per command run. Prefer wide queries over narrow ones — a single decompilation with `--types` is better than five disassembly snippets.
 
@@ -81,7 +109,12 @@ Update KB when you: identify a function's purpose, reconstruct a struct, identif
 
 ## Output
 
-Write all findings to `patches/<project>/findings.md`, creating the file if it doesn't exist. Append to it if it already exists — do not overwrite previous findings. Use clear headings per analysis task so the main agent can read specific sections.
+Write findings to the appropriate file, creating it if needed. Append — do not overwrite previous findings.
+
+- **Default**: `patches/<project>/findings.md`
+- **If told to use r2ghidra for a dual-backend comparison**: `patches/<project>/findings_r2.md`
+
+Use clear headings per analysis task so the main agent can read specific sections.
 
 Format:
 ```markdown

--- a/.claude/rules/subagent-workflow.md
+++ b/.claude/rules/subagent-workflow.md
@@ -6,15 +6,23 @@ description: Subagent delegation rules — when to spawn static-analyzer vs run 
 
 The main agent orchestrates and focuses on **live tools**, **dx9tracer capture**, **user interaction**, and **synthesis**. Heavy static analysis and web research are delegated to subagents so the user isn't blocked.
 
+## Pre-flight: Ensure Ghidra Backend
+
+Before first use of pyghidra, the `static-analyzer` subagent should check if Ghidra is available. Run `python verify_install.py` — if pyghidra/Ghidra shows WARN, run `python verify_install.py --setup` to auto-download JDK 21 + Ghidra 11.4.3 + pyghidra. This is a one-time setup (~600MB download). Skip if pyghidra already shows PASS.
+
 ## Bootstrap First — New Binaries
 
 When analyzing a binary for the first time (no existing or sparsely populated `patches/<project>/kb.h`), **always bootstrap before other static analysis**:
 
 1. The `static-analyzer` subagent auto-pulls `signatures.db` if missing (pre-flight check). Spawn it to run `bootstrap.py <binary> --project <Name>` — this seeds `patches/<project>/kb.h` with RTTI classes, CRT/library function IDs, compiler info, and propagated labels. **Bootstrap takes 2-5 minutes.** Tell the user it's running and do other work while it completes. The output goes to `patches/<project>/kb.h` — verify this file exists and has content after bootstrap returns. **Bootstrap speeds up all subsequent decompilation**: when `--types kb.h` is passed to the decompiler, it pre-analyzes every known function (`af` per KB entry) so cross-references resolve to named functions, callees get inlined signatures, and you avoid the expensive full-binary `aaa` analysis pass.
-2. Any other static analysis subagents should run in parallel, but their decompilation output will be richer if bootstrap finishes first
-3. After bootstrap, all subsequent `decompiler.py` calls **must** use `--types patches/<project>/kb.h`
+2. **In parallel**, spawn a second `static-analyzer` to run `pyghidra_backend.py analyze <binary> --project patches/<Name>`. This runs Ghidra's full analysis (PE loader, MSVC calling convention detection, type propagation, RTTI parsing) and saves a reusable project. **Takes 5-15 minutes.** Once complete, all subsequent decompilations via `--backend auto --project patches/<Name>` will use Ghidra's higher-quality output.
+3. Any other static analysis subagents should run in parallel, but their decompilation output will be richer if bootstrap finishes first
+4. After bootstrap, all subsequent `decompiler.py` calls **must** use `--types patches/<project>/kb.h`
+5. After pyghidra analyze, all subsequent `decompiler.py` calls should also use `--project patches/<project>` so `--backend auto` prefers Ghidra when available
 
 **How to detect "needs bootstrap":** Check if `patches/<project>/kb.h` exists AND has real content (function signatures `@`, globals `$`, or struct definitions beyond section headers). An empty or stub KB with only comment headers counts as sparse — bootstrap it. Quick check: `grep -cE '^[@$]|^struct |^enum ' patches/<project>/kb.h` — if the count is under 50, bootstrap.
+
+**How to detect "needs pyghidra analyze":** Check if `patches/<project>/ghidra/<binary_stem>.gpr` exists. If not, spawn `pyghidra_backend.py analyze`. If kb.h also needs bootstrap, spawn both in parallel.
 
 ## Delegation Rules
 
@@ -26,6 +34,8 @@ When analyzing a binary for the first time (no existing or sparsely populated `p
 | dx9tracer trigger/capture | Main agent — directly |
 | dx9tracer analyze (offline JSONL analysis) | `static-analyzer` subagent |
 | Bootstrap new binary (`bootstrap.py`) | `static-analyzer` subagent -- takes 2-5 min |
+| pyghidra analyze (first-time Ghidra analysis) | `static-analyzer` subagent -- takes 5-15 min |
+| Decompiler with `--backend ghidra` (subsequent) | `static-analyzer` subagent -- fast (JVM ~3s + decompile <1s) |
 | Bulk signature scan (`sigdb.py scan`) | `static-analyzer` subagent -- takes 1-3 min |
 | Signature DB build (`sigdb.py build`) | `static-analyzer` subagent -- takes 1-5 min |
 | Single function ID (`sigdb.py identify`, `fingerprint`) | Main agent -- fast (<5s) |
@@ -48,6 +58,19 @@ When both static and dynamic analysis are needed:
 
 Multiple `static-analyzer` instances can run in parallel for independent questions (e.g., decompiling two unrelated functions, analyzing different modules). When a subagent returns findings with multiple leads (e.g., "5 candidate functions found"), spawn parallel subagents to chase independent leads simultaneously — don't serialize them or try to analyze them yourself.
 
+## Dual-Backend Deep Analysis
+
+For deep analysis tasks (finding subsystems, mapping call chains, understanding large code areas), spawn **two parallel static-analyzer agents using different decompiler backends**:
+
+1. **r2ghidra agent** — uses `--backend pdg` (with `--types kb.h`), writes to `patches/<project>/findings_r2.md`
+2. **pyghidra agent** — uses `pyghidra_backend.py decompile` (requires Ghidra project), writes to `patches/<project>/findings.md`
+
+**Why both:** Each backend has different strengths. r2ghidra is better at `__thiscall` recovery on small functions and low-level D3D details. pyghidra resolves more library calls, finds larger function scopes, and propagates types better. Neither finds everything alone — merging both gives the most complete picture.
+
+**When to use dual-backend:** Complex exploratory tasks ("find the culling system", "map the rendering pipeline", "understand the network protocol"). Not needed for single-function decompilation — use `--backend auto` for that.
+
+**Synthesis:** When both agents return, the main agent reads both findings files and merges them into a unified analysis. Conflicting information is resolved by checking which backend's output is more complete for that specific function.
+
 ## Main Agent Responsibilities During Analysis
 
 **Do not silently wait for subagents.** While static analysis runs:
@@ -59,9 +82,10 @@ Multiple `static-analyzer` instances can run in parallel for independent questio
 ## Examples
 
 **"Disable culling in game.exe"**
-1. Spawn `static-analyzer` in background: find `SetRenderState` calls with `D3DRS_CULLMODE`, string search for "cull", xrefs to render state functions
-2. Immediately tell the user: "Please launch the game — I'll need to attach with livetools to patch culling at runtime once I find the addresses"
-3. When static results return, use `livetools` to verify and patch: `mem write` to NOP the cull-enable instruction or force `D3DRS_CULLMODE` to `D3DCULL_NONE`
+1. Spawn `static-analyzer` #1 (r2ghidra): find `SetRenderState` calls with `D3DRS_CULLMODE`, string search for "cull", xrefs to render state functions. Uses `--backend pdg --types kb.h`. Writes to `findings_r2.md`.
+2. Spawn `static-analyzer` #2 (pyghidra): same search strategy but decompile with `pyghidra_backend.py decompile`. Writes to `findings.md`.
+3. Immediately tell the user: "Please launch the game — I'll need to attach with livetools to patch culling at runtime once I find the addresses"
+4. When both return, merge findings and use `livetools` to verify and patch: `mem write` to NOP the cull-enable instruction or force `D3DRS_CULLMODE` to `D3DCULL_NONE`
 
 **"What does function 0x401000 do?"**
 1. Spawn `static-analyzer`: decompile with `--types kb.h`, get callgraph, xrefs
@@ -78,11 +102,13 @@ Multiple `static-analyzer` instances can run in parallel for independent questio
 2. Tell the user: "Analyzing the crash dump. If you can reproduce the crash, launch the game and I'll attach to catch it live"
 
 **"Analyze game.exe for the first time"**
-1. Spawn `static-analyzer` in background: `bootstrap.py game.exe --project MyGame`
-2. Tell the user: "Bootstrapping the binary -- this will auto-identify RTTI classes, CRT functions, and propagated labels. Takes ~3 minutes."
-3. While bootstrap runs, use `sigdb.py fingerprint` (fast) to tell the user the compiler version
-4. When bootstrap returns, read the report and summarize coverage to the user
-5. All subsequent decompilations use `--types patches/MyGame/kb.h` with the seeded KB
+1. Spawn `static-analyzer` #1 in background: `bootstrap.py game.exe --project MyGame`
+2. Spawn `static-analyzer` #2 in background: `pyghidra_backend.py analyze game.exe --project patches/MyGame`
+3. Tell the user: "Bootstrapping the binary and running Ghidra analysis in parallel. Bootstrap ~3 min, Ghidra ~10 min."
+4. While both run, use `sigdb.py fingerprint` (fast) to tell the user the compiler version
+5. When bootstrap returns, read the report and summarize coverage to the user
+6. When pyghidra returns, tell the user: "Ghidra analysis complete. Subsequent decompilations will use Ghidra's higher-quality output."
+7. All subsequent decompilations use `--types patches/MyGame/kb.h --project patches/MyGame`
 
 ## Anti-Patterns
 

--- a/.claude/rules/tool-catalog.md
+++ b/.claude/rules/tool-catalog.md
@@ -4,7 +4,7 @@ description: Complete catalog of all RE tools (retools, livetools, dx9 tracer) w
 
 # Tool Catalog
 
-**BEFORE FIRST USE**: Run `python verify_install.py` from the repo root. Do NOT proceed with any tool until every check passes. Common failures: missing `git lfs pull` (LFS pointer stubs instead of binaries), missing `pip install -r requirements.txt`.
+**BEFORE FIRST USE**: Run `python verify_install.py` from the repo root. Do NOT proceed with any tool until every required check passes. If pyghidra/Ghidra shows as WARN, run `python verify_install.py --setup` to auto-download JDK 21 + Ghidra + pyghidra. Common failures: missing `git lfs pull` (LFS pointer stubs instead of binaries), missing `pip install -r requirements.txt`.
 
 All tools work on PE binaries (`.exe` and `.dll`). `$B` = path to binary, `$VA` = hex address, `$D` = path to minidump `.dmp` file. Check tools help command for more info on usage.
 Always consult this catalog before making any move to take the best decision on what to use with best bang for your buck.
@@ -41,7 +41,7 @@ Everything else. Tell the subagent WHAT you need, not HOW to run it — it has t
 - "Find instructions using a specific constant" → instruction search
 - "What crashed and what was the error message?" → dump diagnosis + throwmap
 - "Map all throw sites to error strings" → throwmap list
-- "First time analyzing a binary?" → bootstrap (2-5 min)
+- "First time analyzing a binary?" → bootstrap (2-5 min) + pyghidra analyze (5-15 min) in parallel
 - "Bulk signature scan" → sigdb scan (1-3 min)
 - Any combination of the above
 
@@ -64,7 +64,10 @@ Everything else. Tell the subagent WHAT you need, not HOW to run it — it has t
 | Tool | Purpose | Example |
 |------|---------|---------|
 | `disasm.py $B $VA` | Disassemble N instructions at VA | `disasm.py binary.exe 0x401000 -n 50` |
-| `decompiler.py $B $VA --types` | **Ghidra-quality C decompilation** with knowledge base | `python -m retools.decompiler binary.exe 0x401000 --types patches/proj/kb.h` |
+| `decompiler.py $B $VA --types --project` | **C decompilation** -- pyghidra (if project exists) or r2ghidra | `python -m retools.decompiler binary.exe 0x401000 --types patches/proj/kb.h --project patches/proj` |
+| `pyghidra_backend.py analyze $B --project $P` | **Full Ghidra analysis** -- one-time, saves reusable project | `pyghidra_backend.py analyze game.exe --project patches/MyGame` |
+| `pyghidra_backend.py decompile $B $VA --project $P` | Decompile via saved Ghidra project | `pyghidra_backend.py decompile game.exe 0x401000 --project patches/MyGame` |
+| `pyghidra_backend.py status $B --project $P` | Check if Ghidra project exists | `pyghidra_backend.py status game.exe --project patches/MyGame` |
 | `funcinfo.py $B $VA` | Find function start/end, rets, calling convention, callees | `funcinfo.py binary.exe 0x401000` |
 | `cfg.py $B $VA` | Control flow graph (basic blocks + edges, text or mermaid) | `cfg.py binary.exe 0x401000 --format mermaid` |
 | `callgraph.py $B $VA` | Caller/callee tree (multi-level, --up/--down N) | `callgraph.py binary.exe 0x401000 --up 3` |
@@ -246,6 +249,14 @@ Minidumps vary in how much data they capture depending on `MiniDumpWriteDump` fl
 ### `datarefs.py` / `search.py strings --xrefs` -- addressing modes
 
 These tools find references via absolute memory operands, immediate values (with `--imm` flag), and RIP-relative addressing. If you suspect a reference exists but the tool doesn't find it, the address might be computed at runtime. Try `search.py pattern` with the address bytes directly, or use `livetools memwatch`.
+
+### `pyghidra_backend.py` -- requires Ghidra installation
+
+Requires Ghidra 11.x+ installed and `GHIDRA_INSTALL_DIR` environment variable set. **Optional** -- the toolkit works without it (r2ghidra remains the fallback).
+
+**Disk usage**: Ghidra projects are ~10-20x the binary size. A 30MB game exe produces a ~300-600MB `.rep/` directory under `patches/<project>/ghidra/`. This directory is already covered by `.gitignore` (the `patches/` exclusion).
+
+**First-time analysis** takes 5-15 minutes depending on binary size. Subsequent decompilation from the saved project is instant (<1s plus ~3s JVM startup per process).
 
 ### `livetools` -- static vs runtime addresses
 

--- a/.cursor/agents/static-analyzer.md
+++ b/.cursor/agents/static-analyzer.md
@@ -15,24 +15,51 @@ On first invocation, read the full tool catalog at `.cursor/rules/tool-catalog.m
 
 Before any analysis, run these checks in order:
 
-**1. Signature DB**: If `retools/data/signatures.db` does not exist, pull it first:
+**1. Verify install**: Run `python verify_install.py` on first invocation. If pyghidra/Ghidra/Java show as WARN, run `python verify_install.py --setup` to auto-download JDK 21 + Ghidra + pyghidra. One-time ~600MB download.
+
+**2. Signature DB**: If `retools/data/signatures.db` does not exist, pull it first:
 ```bash
 test -f retools/data/signatures.db || python retools/sigdb.py pull
 ```
 
-**2. Bootstrap**: Check if the project KB needs bootstrapping:
+**3. Bootstrap**: Check if the project KB needs bootstrapping:
 ```bash
 grep -cE '^[@$]|^struct |^enum ' patches/<project>/kb.h 2>/dev/null || echo 0
 ```
 If the count is under 50 (or the file doesn't exist), run `python -m retools.bootstrap <binary> --project <Project>` first. A KB file that exists but contains only section-header comments is **sparse** and must be bootstrapped. Do not skip bootstrap just because the file exists.
 
+**4. Ghidra project**: Check if a Ghidra project exists for the binary:
+```bash
+python retools/pyghidra_backend.py status <binary> --project patches/<Project>
+```
+If "Not analyzed", run `python retools/pyghidra_backend.py analyze <binary> --project patches/<Project>`. Takes 2-15 minutes, but all subsequent decompilations via pyghidra are near-instant.
+
 ## Running Tools
 
-Run all tools from the repo root using `python -m retools.<module>` syntax:
+Run all tools from the repo root. Use `python -m retools.<module>` or `python retools/<module>.py` syntax:
 
+### Decompilation (two backends)
+
+**pyghidra (preferred when Ghidra project exists)** — better MSVC type propagation, library call resolution, larger function scope detection:
 ```
-python -m retools.decompiler binary.exe 0x401000
+python retools/pyghidra_backend.py decompile binary.exe 0x401000 --project patches/proj
+```
+
+**r2ghidra (fast fallback)** — better `__thiscall` on small functions, no JVM startup:
+```
 python -m retools.decompiler binary.exe 0x401000 --types patches/proj/kb.h
+python -m retools.decompiler binary.exe 0x401000 --types patches/proj/kb.h --backend pdg
+```
+
+**Auto mode (tries pyghidra first, falls back to r2ghidra)**:
+```
+python -m retools.decompiler binary.exe 0x401000 --types patches/proj/kb.h --project patches/proj
+```
+
+When told to use a specific backend, use it. Otherwise prefer auto mode with both `--types` and `--project`.
+
+### Other tools
+```
 python -m retools.search binary.exe strings -f "error" --xrefs
 python -m retools.xrefs binary.exe 0x401000 -t call
 python -m retools.callgraph binary.exe 0x401000 --up 3
@@ -40,14 +67,15 @@ python -m retools.structrefs binary.exe --aggregate --fn 0x401000 --base esi
 python -m retools.dumpinfo crash.dmp diagnose --binary d3d9.dll
 python -m retools.throwmap d3d9.dll match --dump crash.dmp
 python -m retools.bootstrap binary.exe --project MyGame
-python -m retools.bootstrap binary.exe --project MyGame --db retools/data/signatures.db
 python -m retools.sigdb scan binary.exe --db retools/data/signatures.db
 python -m retools.sigdb identify binary.exe 0x401000 --db retools/data/signatures.db
 python -m retools.sigdb fingerprint binary.exe
 python -m retools.context assemble binary.exe 0x401000 --project MyGame
+python retools/pyghidra_backend.py analyze binary.exe --project patches/MyGame
+python retools/pyghidra_backend.py status binary.exe --project patches/MyGame
 ```
 
-If `retools/data/signatures.db` is missing, run `python -m retools.sigdb pull` to download it before using `sigdb scan` or `sigdb build`.
+If `retools/data/signatures.db` is missing, run `python -m retools.sigdb pull` to download it.
 
 Collect MORE information per command run. Prefer wide queries over narrow ones — a single decompilation with `--types` is better than five disassembly snippets.
 
@@ -80,7 +108,12 @@ Update KB when you: identify a function's purpose, reconstruct a struct, identif
 
 ## Output
 
-Write all findings to `patches/<project>/findings.md`, creating the file if it doesn't exist. Append to it if it already exists — do not overwrite previous findings. Use clear headings per analysis task so the main agent can read specific sections.
+Write findings to the appropriate file, creating it if needed. Append — do not overwrite previous findings.
+
+- **Default**: `patches/<project>/findings.md`
+- **If told to use r2ghidra for a dual-backend comparison**: `patches/<project>/findings_r2.md`
+
+Use clear headings per analysis task so the main agent can read specific sections.
 
 Format:
 ```markdown

--- a/.cursor/rules/subagent-workflow.mdc
+++ b/.cursor/rules/subagent-workflow.mdc
@@ -7,15 +7,23 @@ alwaysApply: true
 
 The main agent orchestrates and focuses on **live tools**, **dx9tracer capture**, **user interaction**, and **synthesis**. Heavy static analysis and web research are delegated to subagents so the user isn't blocked.
 
+## Pre-flight: Ensure Ghidra Backend
+
+Before first use of pyghidra, the `static-analyzer` subagent should check if Ghidra is available. Run `python verify_install.py` — if pyghidra/Ghidra shows WARN, run `python verify_install.py --setup` to auto-download JDK 21 + Ghidra 11.4.3 + pyghidra. This is a one-time setup (~600MB download). Skip if pyghidra already shows PASS.
+
 ## Bootstrap First — New Binaries
 
 When analyzing a binary for the first time (no existing or sparsely populated `patches/<project>/kb.h`), **always bootstrap before other static analysis**:
 
-1. Spawn a `static-analyzer` subagent to run `bootstrap.py <binary> --project <Name>` — this seeds `patches/<project>/kb.h` with RTTI classes, CRT/library function IDs, compiler info, and propagated labels. **Bootstrap takes 2-5 minutes.** Tell the user it's running and do other work while it completes. The output goes to `patches/<project>/kb.h` — verify this file exists and has content after bootstrap returns. **Bootstrap speeds up all subsequent decompilation**: when `--types kb.h` is passed to the decompiler, it pre-analyzes every known function (`af` per KB entry) so cross-references resolve to named functions, callees get inlined signatures, and you avoid the expensive full-binary `aaa` analysis pass.
-2. Any other static analysis subagents should run in parallel, but their decompilation output will be richer if bootstrap finishes first
-3. After bootstrap, all subsequent `decompiler.py` calls **must** use `--types patches/<project>/kb.h`
+1. The `static-analyzer` subagent auto-pulls `signatures.db` if missing (pre-flight check). Spawn it to run `bootstrap.py <binary> --project <Name>` — this seeds `patches/<project>/kb.h` with RTTI classes, CRT/library function IDs, compiler info, and propagated labels. **Bootstrap takes 2-5 minutes.** Tell the user it's running and do other work while it completes. The output goes to `patches/<project>/kb.h` — verify this file exists and has content after bootstrap returns. **Bootstrap speeds up all subsequent decompilation**: when `--types kb.h` is passed to the decompiler, it pre-analyzes every known function (`af` per KB entry) so cross-references resolve to named functions, callees get inlined signatures, and you avoid the expensive full-binary `aaa` analysis pass.
+2. **In parallel**, spawn a second `static-analyzer` to run `pyghidra_backend.py analyze <binary> --project patches/<Name>`. This runs Ghidra's full analysis (PE loader, MSVC calling convention detection, type propagation, RTTI parsing) and saves a reusable project. **Takes 5-15 minutes.** Once complete, all subsequent decompilations via `--backend auto --project patches/<Name>` will use Ghidra's higher-quality output.
+3. Any other static analysis subagents should run in parallel, but their decompilation output will be richer if bootstrap finishes first
+4. After bootstrap, all subsequent `decompiler.py` calls **must** use `--types patches/<project>/kb.h`
+5. After pyghidra analyze, all subsequent `decompiler.py` calls should also use `--project patches/<project>` so `--backend auto` prefers Ghidra when available
 
 **How to detect "needs bootstrap":** Check if `patches/<project>/kb.h` exists AND has real content (function signatures `@`, globals `$`, or struct definitions beyond section headers). An empty or stub KB with only comment headers counts as sparse — bootstrap it. Quick check: `grep -cE '^[@$]|^struct |^enum ' patches/<project>/kb.h` — if the count is under 50, bootstrap.
+
+**How to detect "needs pyghidra analyze":** Check if `patches/<project>/ghidra/<binary_stem>.gpr` exists. If not, spawn `pyghidra_backend.py analyze`. If kb.h also needs bootstrap, spawn both in parallel.
 
 ## Delegation Rules
 
@@ -27,6 +35,8 @@ When analyzing a binary for the first time (no existing or sparsely populated `p
 | dx9tracer trigger/capture | Main agent — directly |
 | dx9tracer analyze (offline JSONL analysis) | `static-analyzer` subagent |
 | Bootstrap new binary (`bootstrap.py`) | `static-analyzer` subagent -- takes 2-5 min |
+| pyghidra analyze (first-time Ghidra analysis) | `static-analyzer` subagent -- takes 5-15 min |
+| Decompiler with `--backend ghidra` (subsequent) | `static-analyzer` subagent -- fast (JVM ~3s + decompile <1s) |
 | Bulk signature scan (`sigdb.py scan`) | `static-analyzer` subagent -- takes 1-3 min |
 | Signature DB build (`sigdb.py build`) | `static-analyzer` subagent -- takes 1-5 min |
 | Single function ID (`sigdb.py identify`, `fingerprint`) | Main agent -- fast (<5s) |
@@ -49,6 +59,19 @@ When both static and dynamic analysis are needed:
 
 Multiple `static-analyzer` instances can run in parallel for independent questions (e.g., decompiling two unrelated functions, analyzing different modules). When a subagent returns findings with multiple leads (e.g., "5 candidate functions found"), spawn parallel subagents to chase independent leads simultaneously — don't serialize them or try to analyze them yourself.
 
+## Dual-Backend Deep Analysis
+
+For deep analysis tasks (finding subsystems, mapping call chains, understanding large code areas), spawn **two parallel static-analyzer agents using different decompiler backends**:
+
+1. **r2ghidra agent** — uses `--backend pdg` (with `--types kb.h`), writes to `patches/<project>/findings_r2.md`
+2. **pyghidra agent** — uses `pyghidra_backend.py decompile` (requires Ghidra project), writes to `patches/<project>/findings.md`
+
+**Why both:** Each backend has different strengths. r2ghidra is better at `__thiscall` recovery on small functions and low-level D3D details. pyghidra resolves more library calls, finds larger function scopes, and propagates types better. Neither finds everything alone — merging both gives the most complete picture.
+
+**When to use dual-backend:** Complex exploratory tasks ("find the culling system", "map the rendering pipeline", "understand the network protocol"). Not needed for single-function decompilation — use `--backend auto` for that.
+
+**Synthesis:** When both agents return, the main agent reads both findings files and merges them into a unified analysis. Conflicting information is resolved by checking which backend's output is more complete for that specific function.
+
 ## Main Agent Responsibilities During Analysis
 
 **Do not silently wait for subagents.** While static analysis runs:
@@ -60,9 +83,10 @@ Multiple `static-analyzer` instances can run in parallel for independent questio
 ## Examples
 
 **"Disable culling in game.exe"**
-1. Spawn `static-analyzer` in background: find `SetRenderState` calls with `D3DRS_CULLMODE`, string search for "cull", xrefs to render state functions
-2. Immediately tell the user: "Please launch the game — I'll need to attach with livetools to patch culling at runtime once I find the addresses"
-3. When static results return, use `livetools` to verify and patch: `mem write` to NOP the cull-enable instruction or force `D3DRS_CULLMODE` to `D3DCULL_NONE`
+1. Spawn `static-analyzer` #1 (r2ghidra): find `SetRenderState` calls with `D3DRS_CULLMODE`, string search for "cull", xrefs to render state functions. Uses `--backend pdg --types kb.h`. Writes to `findings_r2.md`.
+2. Spawn `static-analyzer` #2 (pyghidra): same search strategy but decompile with `pyghidra_backend.py decompile`. Writes to `findings.md`.
+3. Immediately tell the user: "Please launch the game — I'll need to attach with livetools to patch culling at runtime once I find the addresses"
+4. When both return, merge findings and use `livetools` to verify and patch: `mem write` to NOP the cull-enable instruction or force `D3DRS_CULLMODE` to `D3DCULL_NONE`
 
 **"What does function 0x401000 do?"**
 1. Spawn `static-analyzer`: decompile with `--types kb.h`, get callgraph, xrefs
@@ -79,11 +103,13 @@ Multiple `static-analyzer` instances can run in parallel for independent questio
 2. Tell the user: "Analyzing the crash dump. If you can reproduce the crash, launch the game and I'll attach to catch it live"
 
 **"Analyze game.exe for the first time"**
-1. Spawn `static-analyzer` in background: `bootstrap.py game.exe --project MyGame`
-2. Tell the user: "Bootstrapping the binary -- this will auto-identify RTTI classes, CRT functions, and propagated labels. Takes ~3 minutes."
-3. While bootstrap runs, use `sigdb.py fingerprint` (fast) to tell the user the compiler version
-4. When bootstrap returns, read the report and summarize coverage to the user
-5. All subsequent decompilations use `--types patches/MyGame/kb.h` with the seeded KB
+1. Spawn `static-analyzer` #1 in background: `bootstrap.py game.exe --project MyGame`
+2. Spawn `static-analyzer` #2 in background: `pyghidra_backend.py analyze game.exe --project patches/MyGame`
+3. Tell the user: "Bootstrapping the binary and running Ghidra analysis in parallel. Bootstrap ~3 min, Ghidra ~10 min."
+4. While both run, use `sigdb.py fingerprint` (fast) to tell the user the compiler version
+5. When bootstrap returns, read the report and summarize coverage to the user
+6. When pyghidra returns, tell the user: "Ghidra analysis complete. Subsequent decompilations will use Ghidra's higher-quality output."
+7. All subsequent decompilations use `--types patches/MyGame/kb.h --project patches/MyGame`
 
 ## Anti-Patterns
 

--- a/.cursor/rules/tool-catalog.mdc
+++ b/.cursor/rules/tool-catalog.mdc
@@ -5,7 +5,7 @@ alwaysApply: true
 
 # Tool Catalog
 
-**BEFORE FIRST USE**: Run `python verify_install.py` from the repo root. Do NOT proceed with any tool until every check passes. Common failures: missing `git lfs pull` (LFS pointer stubs instead of binaries), missing `pip install -r requirements.txt`.
+**BEFORE FIRST USE**: Run `python verify_install.py` from the repo root. Do NOT proceed with any tool until every required check passes. If pyghidra/Ghidra shows as WARN, run `python verify_install.py --setup` to auto-download JDK 21 + Ghidra + pyghidra. Common failures: missing `git lfs pull` (LFS pointer stubs instead of binaries), missing `pip install -r requirements.txt`.
 
 All tools work on PE binaries (`.exe` and `.dll`). `$B` = path to binary, `$VA` = hex address, `$D` = path to minidump `.dmp` file. Check tools help command for more info on usage.
 Always consult this catalog before making any move to take the best decision on what to use with best bang for your buck.
@@ -42,7 +42,7 @@ Everything else. Tell the subagent WHAT you need, not HOW to run it — it has t
 - "Find instructions using a specific constant" → instruction search
 - "What crashed and what was the error message?" → dump diagnosis + throwmap
 - "Map all throw sites to error strings" → throwmap list
-- "First time analyzing a binary?" → bootstrap (2-5 min)
+- "First time analyzing a binary?" → bootstrap (2-5 min) + pyghidra analyze (5-15 min) in parallel
 - "Bulk signature scan" → sigdb scan (1-3 min)
 - Any combination of the above
 
@@ -65,7 +65,10 @@ Everything else. Tell the subagent WHAT you need, not HOW to run it — it has t
 | Tool | Purpose | Example |
 |------|---------|---------|
 | `disasm.py $B $VA` | Disassemble N instructions at VA | `disasm.py binary.exe 0x401000 -n 50` |
-| `decompiler.py $B $VA --types` | **Ghidra-quality C decompilation** with knowledge base | `python -m retools.decompiler binary.exe 0x401000 --types patches/proj/kb.h` |
+| `decompiler.py $B $VA --types --project` | **C decompilation** -- pyghidra (if project exists) or r2ghidra | `python -m retools.decompiler binary.exe 0x401000 --types patches/proj/kb.h --project patches/proj` |
+| `pyghidra_backend.py analyze $B --project $P` | **Full Ghidra analysis** -- one-time, saves reusable project | `pyghidra_backend.py analyze game.exe --project patches/MyGame` |
+| `pyghidra_backend.py decompile $B $VA --project $P` | Decompile via saved Ghidra project | `pyghidra_backend.py decompile game.exe 0x401000 --project patches/MyGame` |
+| `pyghidra_backend.py status $B --project $P` | Check if Ghidra project exists | `pyghidra_backend.py status game.exe --project patches/MyGame` |
 | `funcinfo.py $B $VA` | Find function start/end, rets, calling convention, callees | `funcinfo.py binary.exe 0x401000` |
 | `cfg.py $B $VA` | Control flow graph (basic blocks + edges, text or mermaid) | `cfg.py binary.exe 0x401000 --format mermaid` |
 | `callgraph.py $B $VA` | Caller/callee tree (multi-level, --up/--down N) | `callgraph.py binary.exe 0x401000 --up 3` |
@@ -247,6 +250,14 @@ Minidumps vary in how much data they capture depending on `MiniDumpWriteDump` fl
 ### `datarefs.py` / `search.py strings --xrefs` -- addressing modes
 
 These tools find references via absolute memory operands, immediate values (with `--imm` flag), and RIP-relative addressing. If you suspect a reference exists but the tool doesn't find it, the address might be computed at runtime. Try `search.py pattern` with the address bytes directly, or use `livetools memwatch`.
+
+### `pyghidra_backend.py` -- requires Ghidra installation
+
+Requires Ghidra 11.x+ installed and `GHIDRA_INSTALL_DIR` environment variable set. **Optional** -- the toolkit works without it (r2ghidra remains the fallback).
+
+**Disk usage**: Ghidra projects are ~10-20x the binary size. A 30MB game exe produces a ~300-600MB `.rep/` directory under `patches/<project>/ghidra/`. This directory is already covered by `.gitignore` (the `patches/` exclusion).
+
+**First-time analysis** takes 5-15 minutes depending on binary size. Subsequent decompilation from the saved project is instant (<1s plus ~3s JVM startup per process).
 
 ### `livetools` -- static vs runtime addresses
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,9 @@ On first use, or if `kb.h` is missing or contains only minimal content, automati
 `python -m retools.bootstrap <binary> --project <ProjectName>`
 before any further static or dynamic analysis. **Bootstrap takes 2-5 minutes** — it scans for RTTI classes, identifies CRT/library functions, and propagates labels. The output goes to `patches/<ProjectName>/kb.h` — verify this file exists and has content after bootstrap returns. All subsequent `decompiler.py` calls must use `--types patches/<ProjectName>/kb.h`. **Bootstrap speeds up all subsequent decompilation**: `--types` pre-analyzes every known function so cross-references resolve to named functions and you avoid the expensive full-binary analysis pass. Tell the user it's running and do other work while it completes.
 
-Run `python verify_install.py` from the repo root before first use. Common failures: missing `git lfs pull` (LFS pointer stubs instead of real binaries), missing `pip install -r requirements.txt`.
+**In parallel with bootstrap**, run `python retools/pyghidra_backend.py analyze <binary> --project patches/<ProjectName>` to create a reusable Ghidra project. This takes 5-15 minutes but makes all subsequent pyghidra decompilations near-instant. Both bootstrap and pyghidra analyze can run simultaneously.
+
+Run `python verify_install.py` from the repo root before first use. If pyghidra/Ghidra shows as WARN, run `python verify_install.py --setup` to auto-download JDK 21 + Ghidra + pyghidra (~600MB one-time download). Common failures: missing `git lfs pull` (LFS pointer stubs instead of real binaries), missing `pip install -r requirements.txt`.
 
 ## Delegation Rule
 
@@ -19,6 +21,7 @@ Run `python verify_install.py` from the repo root before first use. Common failu
 - `context.py assemble` / `postprocess` — context gathering and decompiler annotation
 - `readmem.py` — single typed read from a PE file
 - `asi_patcher.py build` — build step, not analysis
+- `pyghidra_backend.py status` — project existence check (<1s)
 
 If you're about to run a second `retools` command in the same turn, stop and delegate everything to a subagent.
 
@@ -27,6 +30,17 @@ Run all tools from the repo root using `python -m <module>` syntax (e.g. `python
 ## Live Tools First
 
 The main agent owns `livetools` — always use them to verify static findings and act on leads from subagents. When a subagent returns addresses or candidates, immediately follow up with live tools (trace, breakpoint, mem read/write) rather than spawning more static analysis. Static analysis finds clues; live tools confirm and act on them. Do not wait idle for subagents — use live tools to explore independently while static analysis runs in the background.
+
+## Dual-Backend Decompilation
+
+The decompiler supports two backends with different strengths:
+
+- **pyghidra (preferred)** — better MSVC type propagation, library call resolution, larger function scope detection. Requires a Ghidra project (`pyghidra_backend.py analyze` creates one). Use when `patches/<project>/ghidra/<binary>.gpr` exists.
+- **r2ghidra (fallback)** — better `__thiscall` on small functions, no JVM startup. Always available.
+
+**Auto mode**: `python -m retools.decompiler binary.exe 0x401000 --types patches/proj/kb.h --project patches/proj` tries pyghidra first, falls back to r2ghidra. Use `--project` alongside `--types` for auto selection.
+
+**Dual-backend deep analysis**: For complex exploratory tasks (finding subsystems, mapping call chains), run both backends in parallel on the same functions and merge findings. r2ghidra results go to `findings_r2.md`, pyghidra to `findings.md`. Neither backend finds everything alone -- merging both gives the most complete picture.
 
 ## Engineering Standards
 

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,22 @@ retools/data/signatures.db
 retools/data/sources/
 *.db-shm
 *.db-wal
+
+# Ghidra + JDK (downloaded via verify_install.py --setup)
+tools/ghidra_*/
+tools/jdk-*/
+
+# Target binaries (not part of the toolkit)
+*.exe
+*.dll
+!graphics/directx/dx9/tracer/src/*.dll
+
+
+# Research artifacts
+compass_artifact_*
+
+# Agent memory (machine-specific, regenerated per session)
+.claude/agent-memory/
+
+# Superpowers specs/plans (session artifacts)
+docs/

--- a/.kiro/agents/static-analyzer.md
+++ b/.kiro/agents/static-analyzer.md
@@ -15,24 +15,51 @@ On first invocation, read the full tool catalog at `.claude/rules/tool-catalog.m
 
 Before any analysis, run these checks in order:
 
-**1. Signature DB**: If `retools/data/signatures.db` does not exist, pull it first:
+**1. Verify install**: Run `python verify_install.py` on first invocation. If pyghidra/Ghidra/Java show as WARN, run `python verify_install.py --setup` to auto-download JDK 21 + Ghidra + pyghidra. One-time ~600MB download.
+
+**2. Signature DB**: If `retools/data/signatures.db` does not exist, pull it first:
 ```bash
 test -f retools/data/signatures.db || python retools/sigdb.py pull
 ```
 
-**2. Bootstrap**: Check if the project KB needs bootstrapping:
+**3. Bootstrap**: Check if the project KB needs bootstrapping:
 ```bash
 grep -cE '^[@$]|^struct |^enum ' patches/<project>/kb.h 2>/dev/null || echo 0
 ```
 If the count is under 50 (or the file doesn't exist), run `python -m retools.bootstrap <binary> --project <Project>` first. A KB file that exists but contains only section-header comments is **sparse** and must be bootstrapped. Do not skip bootstrap just because the file exists.
 
+**4. Ghidra project**: Check if a Ghidra project exists for the binary:
+```bash
+python retools/pyghidra_backend.py status <binary> --project patches/<Project>
+```
+If "Not analyzed", run `python retools/pyghidra_backend.py analyze <binary> --project patches/<Project>`. Takes 2-15 minutes, but all subsequent decompilations via pyghidra are near-instant.
+
 ## Running Tools
 
-Run all tools from the repo root using `python -m retools.<module>` syntax:
+Run all tools from the repo root. Use `python -m retools.<module>` or `python retools/<module>.py` syntax:
 
+### Decompilation (two backends)
+
+**pyghidra (preferred when Ghidra project exists)** — better MSVC type propagation, library call resolution, larger function scope detection:
 ```
-python -m retools.decompiler binary.exe 0x401000
+python retools/pyghidra_backend.py decompile binary.exe 0x401000 --project patches/proj
+```
+
+**r2ghidra (fast fallback)** — better `__thiscall` on small functions, no JVM startup:
+```
 python -m retools.decompiler binary.exe 0x401000 --types patches/proj/kb.h
+python -m retools.decompiler binary.exe 0x401000 --types patches/proj/kb.h --backend pdg
+```
+
+**Auto mode (tries pyghidra first, falls back to r2ghidra)**:
+```
+python -m retools.decompiler binary.exe 0x401000 --types patches/proj/kb.h --project patches/proj
+```
+
+When told to use a specific backend, use it. Otherwise prefer auto mode with both `--types` and `--project`.
+
+### Other tools
+```
 python -m retools.search binary.exe strings -f "error" --xrefs
 python -m retools.xrefs binary.exe 0x401000 -t call
 python -m retools.callgraph binary.exe 0x401000 --up 3
@@ -40,14 +67,15 @@ python -m retools.structrefs binary.exe --aggregate --fn 0x401000 --base esi
 python -m retools.dumpinfo crash.dmp diagnose --binary d3d9.dll
 python -m retools.throwmap d3d9.dll match --dump crash.dmp
 python -m retools.bootstrap binary.exe --project MyGame
-python -m retools.bootstrap binary.exe --project MyGame --db retools/data/signatures.db
 python -m retools.sigdb scan binary.exe --db retools/data/signatures.db
 python -m retools.sigdb identify binary.exe 0x401000 --db retools/data/signatures.db
 python -m retools.sigdb fingerprint binary.exe
 python -m retools.context assemble binary.exe 0x401000 --project MyGame
+python retools/pyghidra_backend.py analyze binary.exe --project patches/MyGame
+python retools/pyghidra_backend.py status binary.exe --project patches/MyGame
 ```
 
-If `retools/data/signatures.db` is missing, run `python -m retools.sigdb pull` to download it before using `sigdb scan` or `sigdb build`.
+If `retools/data/signatures.db` is missing, run `python -m retools.sigdb pull` to download it.
 
 Collect MORE information per command run. Prefer wide queries over narrow ones — a single decompilation with `--types` is better than five disassembly snippets.
 
@@ -80,7 +108,12 @@ Update KB when you: identify a function's purpose, reconstruct a struct, identif
 
 ## Output
 
-Write all findings to `patches/<project>/findings.md`, creating the file if it doesn't exist. Append to it if it already exists — do not overwrite previous findings. Use clear headings per analysis task so the main agent can read specific sections.
+Write findings to the appropriate file, creating it if needed. Append — do not overwrite previous findings.
+
+- **Default**: `patches/<project>/findings.md`
+- **If told to use r2ghidra for a dual-backend comparison**: `patches/<project>/findings_r2.md`
+
+Use clear headings per analysis task so the main agent can read specific sections.
 
 Format:
 ```markdown

--- a/.kiro/steering/subagent-workflow.md
+++ b/.kiro/steering/subagent-workflow.md
@@ -7,15 +7,23 @@ inclusion: always
 
 The main agent orchestrates and focuses on **live tools**, **dx9tracer capture**, **user interaction**, and **synthesis**. Heavy static analysis and web research are delegated to subagents so the user isn't blocked.
 
+## Pre-flight: Ensure Ghidra Backend
+
+Before first use of pyghidra, the `static-analyzer` subagent should check if Ghidra is available. Run `python verify_install.py` — if pyghidra/Ghidra shows WARN, run `python verify_install.py --setup` to auto-download JDK 21 + Ghidra 11.4.3 + pyghidra. This is a one-time setup (~600MB download). Skip if pyghidra already shows PASS.
+
 ## Bootstrap First — New Binaries
 
 When analyzing a binary for the first time (no existing or sparsely populated `patches/<project>/kb.h`), **always bootstrap before other static analysis**:
 
-1. Spawn a `static-analyzer` subagent to run `bootstrap.py <binary> --project <Name>` — this seeds `patches/<project>/kb.h` with RTTI classes, CRT/library function IDs, compiler info, and propagated labels. **Bootstrap takes 2-5 minutes.** Tell the user it's running and do other work while it completes. The output goes to `patches/<project>/kb.h` — verify this file exists and has content after bootstrap returns. **Bootstrap speeds up all subsequent decompilation**: when `--types kb.h` is passed to the decompiler, it pre-analyzes every known function (`af` per KB entry) so cross-references resolve to named functions, callees get inlined signatures, and you avoid the expensive full-binary `aaa` analysis pass.
-2. Any other static analysis subagents should run in parallel, but their decompilation output will be richer if bootstrap finishes first
-3. After bootstrap, all subsequent `decompiler.py` calls **must** use `--types patches/<project>/kb.h`
+1. The `static-analyzer` subagent auto-pulls `signatures.db` if missing (pre-flight check). Spawn it to run `bootstrap.py <binary> --project <Name>` — this seeds `patches/<project>/kb.h` with RTTI classes, CRT/library function IDs, compiler info, and propagated labels. **Bootstrap takes 2-5 minutes.** Tell the user it's running and do other work while it completes. The output goes to `patches/<project>/kb.h` — verify this file exists and has content after bootstrap returns. **Bootstrap speeds up all subsequent decompilation**: when `--types kb.h` is passed to the decompiler, it pre-analyzes every known function (`af` per KB entry) so cross-references resolve to named functions, callees get inlined signatures, and you avoid the expensive full-binary `aaa` analysis pass.
+2. **In parallel**, spawn a second `static-analyzer` to run `pyghidra_backend.py analyze <binary> --project patches/<Name>`. This runs Ghidra's full analysis (PE loader, MSVC calling convention detection, type propagation, RTTI parsing) and saves a reusable project. **Takes 5-15 minutes.** Once complete, all subsequent decompilations via `--backend auto --project patches/<Name>` will use Ghidra's higher-quality output.
+3. Any other static analysis subagents should run in parallel, but their decompilation output will be richer if bootstrap finishes first
+4. After bootstrap, all subsequent `decompiler.py` calls **must** use `--types patches/<project>/kb.h`
+5. After pyghidra analyze, all subsequent `decompiler.py` calls should also use `--project patches/<project>` so `--backend auto` prefers Ghidra when available
 
 **How to detect "needs bootstrap":** Check if `patches/<project>/kb.h` exists AND has real content (function signatures `@`, globals `$`, or struct definitions beyond section headers). An empty or stub KB with only comment headers counts as sparse — bootstrap it. Quick check: `grep -cE '^[@$]|^struct |^enum ' patches/<project>/kb.h` — if the count is under 50, bootstrap.
+
+**How to detect "needs pyghidra analyze":** Check if `patches/<project>/ghidra/<binary_stem>.gpr` exists. If not, spawn `pyghidra_backend.py analyze`. If kb.h also needs bootstrap, spawn both in parallel.
 
 ## Delegation Rules
 
@@ -27,6 +35,8 @@ When analyzing a binary for the first time (no existing or sparsely populated `p
 | dx9tracer trigger/capture | Main agent — directly |
 | dx9tracer analyze (offline JSONL analysis) | `static-analyzer` subagent |
 | Bootstrap new binary (`bootstrap.py`) | `static-analyzer` subagent -- takes 2-5 min |
+| pyghidra analyze (first-time Ghidra analysis) | `static-analyzer` subagent -- takes 5-15 min |
+| Decompiler with `--backend ghidra` (subsequent) | `static-analyzer` subagent -- fast (JVM ~3s + decompile <1s) |
 | Bulk signature scan (`sigdb.py scan`) | `static-analyzer` subagent -- takes 1-3 min |
 | Signature DB build (`sigdb.py build`) | `static-analyzer` subagent -- takes 1-5 min |
 | Single function ID (`sigdb.py identify`, `fingerprint`) | Main agent -- fast (<5s) |
@@ -49,6 +59,19 @@ When both static and dynamic analysis are needed:
 
 Multiple `static-analyzer` instances can run in parallel for independent questions (e.g., decompiling two unrelated functions, analyzing different modules). When a subagent returns findings with multiple leads (e.g., "5 candidate functions found"), spawn parallel subagents to chase independent leads simultaneously — don't serialize them or try to analyze them yourself.
 
+## Dual-Backend Deep Analysis
+
+For deep analysis tasks (finding subsystems, mapping call chains, understanding large code areas), spawn **two parallel static-analyzer agents using different decompiler backends**:
+
+1. **r2ghidra agent** — uses `--backend pdg` (with `--types kb.h`), writes to `patches/<project>/findings_r2.md`
+2. **pyghidra agent** — uses `pyghidra_backend.py decompile` (requires Ghidra project), writes to `patches/<project>/findings.md`
+
+**Why both:** Each backend has different strengths. r2ghidra is better at `__thiscall` recovery on small functions and low-level D3D details. pyghidra resolves more library calls, finds larger function scopes, and propagates types better. Neither finds everything alone — merging both gives the most complete picture.
+
+**When to use dual-backend:** Complex exploratory tasks ("find the culling system", "map the rendering pipeline", "understand the network protocol"). Not needed for single-function decompilation — use `--backend auto` for that.
+
+**Synthesis:** When both agents return, the main agent reads both findings files and merges them into a unified analysis. Conflicting information is resolved by checking which backend's output is more complete for that specific function.
+
 ## Main Agent Responsibilities During Analysis
 
 **Do not silently wait for subagents.** While static analysis runs:
@@ -60,9 +83,10 @@ Multiple `static-analyzer` instances can run in parallel for independent questio
 ## Examples
 
 **"Disable culling in game.exe"**
-1. Spawn `static-analyzer` in background: find `SetRenderState` calls with `D3DRS_CULLMODE`, string search for "cull", xrefs to render state functions
-2. Immediately tell the user: "Please launch the game — I'll need to attach with livetools to patch culling at runtime once I find the addresses"
-3. When static results return, use `livetools` to verify and patch: `mem write` to NOP the cull-enable instruction or force `D3DRS_CULLMODE` to `D3DCULL_NONE`
+1. Spawn `static-analyzer` #1 (r2ghidra): find `SetRenderState` calls with `D3DRS_CULLMODE`, string search for "cull", xrefs to render state functions. Uses `--backend pdg --types kb.h`. Writes to `findings_r2.md`.
+2. Spawn `static-analyzer` #2 (pyghidra): same search strategy but decompile with `pyghidra_backend.py decompile`. Writes to `findings.md`.
+3. Immediately tell the user: "Please launch the game — I'll need to attach with livetools to patch culling at runtime once I find the addresses"
+4. When both return, merge findings and use `livetools` to verify and patch: `mem write` to NOP the cull-enable instruction or force `D3DRS_CULLMODE` to `D3DCULL_NONE`
 
 **"What does function 0x401000 do?"**
 1. Spawn `static-analyzer`: decompile with `--types kb.h`, get callgraph, xrefs
@@ -79,11 +103,13 @@ Multiple `static-analyzer` instances can run in parallel for independent questio
 2. Tell the user: "Analyzing the crash dump. If you can reproduce the crash, launch the game and I'll attach to catch it live"
 
 **"Analyze game.exe for the first time"**
-1. Spawn `static-analyzer` in background: `bootstrap.py game.exe --project MyGame`
-2. Tell the user: "Bootstrapping the binary -- this will auto-identify RTTI classes, CRT functions, and propagated labels. Takes ~3 minutes."
-3. While bootstrap runs, use `sigdb.py fingerprint` (fast) to tell the user the compiler version
-4. When bootstrap returns, read the report and summarize coverage to the user
-5. All subsequent decompilations use `--types patches/MyGame/kb.h` with the seeded KB
+1. Spawn `static-analyzer` #1 in background: `bootstrap.py game.exe --project MyGame`
+2. Spawn `static-analyzer` #2 in background: `pyghidra_backend.py analyze game.exe --project patches/MyGame`
+3. Tell the user: "Bootstrapping the binary and running Ghidra analysis in parallel. Bootstrap ~3 min, Ghidra ~10 min."
+4. While both run, use `sigdb.py fingerprint` (fast) to tell the user the compiler version
+5. When bootstrap returns, read the report and summarize coverage to the user
+6. When pyghidra returns, tell the user: "Ghidra analysis complete. Subsequent decompilations will use Ghidra's higher-quality output."
+7. All subsequent decompilations use `--types patches/MyGame/kb.h --project patches/MyGame`
 
 ## Anti-Patterns
 

--- a/.kiro/steering/tool-catalog.md
+++ b/.kiro/steering/tool-catalog.md
@@ -5,7 +5,7 @@ inclusion: auto
 
 # Tool Catalog
 
-**BEFORE FIRST USE**: Run `python verify_install.py` from the repo root. Do NOT proceed with any tool until every check passes. Common failures: missing `git lfs pull` (LFS pointer stubs instead of binaries), missing `pip install -r requirements.txt`.
+**BEFORE FIRST USE**: Run `python verify_install.py` from the repo root. Do NOT proceed with any tool until every required check passes. If pyghidra/Ghidra shows as WARN, run `python verify_install.py --setup` to auto-download JDK 21 + Ghidra + pyghidra. Common failures: missing `git lfs pull` (LFS pointer stubs instead of binaries), missing `pip install -r requirements.txt`.
 
 All tools work on PE binaries (`.exe` and `.dll`). `$B` = path to binary, `$VA` = hex address, `$D` = path to minidump `.dmp` file. Check tools help command for more info on usage.
 Always consult this catalog before making any move to take the best decision on what to use with best bang for your buck.
@@ -42,7 +42,7 @@ Everything else. Tell the subagent WHAT you need, not HOW to run it — it has t
 - "Find instructions using a specific constant" → instruction search
 - "What crashed and what was the error message?" → dump diagnosis + throwmap
 - "Map all throw sites to error strings" → throwmap list
-- "First time analyzing a binary?" → bootstrap (2-5 min)
+- "First time analyzing a binary?" → bootstrap (2-5 min) + pyghidra analyze (5-15 min) in parallel
 - "Bulk signature scan" → sigdb scan (1-3 min)
 - Any combination of the above
 
@@ -65,7 +65,10 @@ Everything else. Tell the subagent WHAT you need, not HOW to run it — it has t
 | Tool | Purpose | Example |
 |------|---------|---------|
 | `disasm.py $B $VA` | Disassemble N instructions at VA | `disasm.py binary.exe 0x401000 -n 50` |
-| `decompiler.py $B $VA --types` | **Ghidra-quality C decompilation** with knowledge base | `python -m retools.decompiler binary.exe 0x401000 --types patches/proj/kb.h` |
+| `decompiler.py $B $VA --types --project` | **C decompilation** -- pyghidra (if project exists) or r2ghidra | `python -m retools.decompiler binary.exe 0x401000 --types patches/proj/kb.h --project patches/proj` |
+| `pyghidra_backend.py analyze $B --project $P` | **Full Ghidra analysis** -- one-time, saves reusable project | `pyghidra_backend.py analyze game.exe --project patches/MyGame` |
+| `pyghidra_backend.py decompile $B $VA --project $P` | Decompile via saved Ghidra project | `pyghidra_backend.py decompile game.exe 0x401000 --project patches/MyGame` |
+| `pyghidra_backend.py status $B --project $P` | Check if Ghidra project exists | `pyghidra_backend.py status game.exe --project patches/MyGame` |
 | `funcinfo.py $B $VA` | Find function start/end, rets, calling convention, callees | `funcinfo.py binary.exe 0x401000` |
 | `cfg.py $B $VA` | Control flow graph (basic blocks + edges, text or mermaid) | `cfg.py binary.exe 0x401000 --format mermaid` |
 | `callgraph.py $B $VA` | Caller/callee tree (multi-level, --up/--down N) | `callgraph.py binary.exe 0x401000 --up 3` |
@@ -247,6 +250,14 @@ Minidumps vary in how much data they capture depending on `MiniDumpWriteDump` fl
 ### `datarefs.py` / `search.py strings --xrefs` -- addressing modes
 
 These tools find references via absolute memory operands, immediate values (with `--imm` flag), and RIP-relative addressing. If you suspect a reference exists but the tool doesn't find it, the address might be computed at runtime. Try `search.py pattern` with the address bytes directly, or use `livetools memwatch`.
+
+### `pyghidra_backend.py` -- requires Ghidra installation
+
+Requires Ghidra 11.x+ installed and `GHIDRA_INSTALL_DIR` environment variable set. **Optional** -- the toolkit works without it (r2ghidra remains the fallback).
+
+**Disk usage**: Ghidra projects are ~10-20x the binary size. A 30MB game exe produces a ~300-600MB `.rep/` directory under `patches/<project>/ghidra/`. This directory is already covered by `.gitignore` (the `patches/` exclusion).
+
+**First-time analysis** takes 5-15 minutes depending on binary size. Subsequent decompilation from the saved project is instant (<1s plus ~3s JVM startup per process).
 
 ### `livetools` -- static vs runtime addresses
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ r2pipe>=1.9.8
 pefile>=2024.8.26
 capstone>=5.0.7
 minidump>=0.0.24
+pyghidra>=2.0.0,<4.0.0

--- a/retools/context.py
+++ b/retools/context.py
@@ -25,8 +25,8 @@ from structrefs import aggregate_struct
 from search import find_strings
 from sigdb import SignatureDB, extract_structural_sig
 
-# Pattern: fcn.XXXXXXXX where X is hex (case-insensitive)
-_FCN_RE = re.compile(r"fcn\.([0-9a-fA-F]{8})")
+# Pattern: fcn.XXXXXXXX or FUN_XXXXXXXX (r2ghidra or Ghidra naming)
+_FCN_RE = re.compile(r"(?:fcn\.|FUN_)([0-9a-fA-F]{8,16})")
 
 # Pattern: *(type *)(var + 0xOFFSET)
 _STRUCT_ACCESS_RE = re.compile(

--- a/retools/decompiler.py
+++ b/retools/decompiler.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
-"""Decompile a function from a PE binary using radare2 + r2ghidra/pdc.
+"""Decompile a function from a PE binary.
 
-Produces pseudo-C output for the function at the given virtual address.
-Uses r2ghidra (pdg) when available, falling back to r2's built-in pdc.
+Uses pyghidra (headless Ghidra) when a Ghidra project exists, falling back
+to radare2 + r2ghidra/pdc. pyghidra runs Ghidra's full analysis pipeline
+for richer type/calling convention recovery, but requires a one-time
+analysis pass via pyghidra_backend.py.
 
 Supports loading type/function/global metadata via ``--types`` to produce
 richer decompiled output (named structs, function names, enum values).
@@ -15,6 +17,7 @@ Usage:
     python -m retools.decompiler <binary> <va>
     python -m retools.decompiler <binary> <va> --types kb.h
     python -m retools.decompiler <binary> <va> --backend pdc
+    python -m retools.decompiler <binary> <va> --project patches/MyGame --backend ghidra
 
 Knowledge base format (``--types`` input):
     // C type definitions (struct, enum, typedef) -- no prefix
@@ -30,7 +33,7 @@ Knowledge base format (``--types`` input):
 Examples:
     python -m retools.decompiler binary.exe 0x401000
     python -m retools.decompiler binary.exe 0x401000 --types project/kb.h
-    python -m retools.decompiler binary.exe 0x401000 --types "struct V { float x; float y; float z; };"
+    python -m retools.decompiler binary.exe 0x401000 --project patches/MyGame --backend ghidra
 """
 
 import argparse
@@ -124,16 +127,38 @@ def _load_types(r2, types_arg: str) -> None:
 
 
 def decompile(binary: str, va: int, *, backend: str = "auto",
-              full_analysis: bool = False, types: str | None = None) -> str:
+              full_analysis: bool = False, types: str | None = None,
+              project_dir: str | None = None) -> str:
     """Decompile the function at *va* and return pseudo-C as a string.
 
     Args:
         binary: Path to PE file.
         va: Virtual address of the function.
-        backend: Decompiler backend ("auto", "pdg", "pdc", "pdd").
+        backend: Decompiler backend ("auto", "ghidra", "pyhidra", "pdg", "pdc", "pdd").
         full_analysis: If True, run ``aaa`` before decompiling.
         types: Knowledge-base string, stdin marker (``-``), or file path.
+        project_dir: Project directory (e.g. ``patches/MyGame``). Enables
+            pyghidra backend when a Ghidra project exists at ``<project_dir>/ghidra/``.
     """
+    # -- pyghidra backend routing --
+    if backend in ("ghidra", "pyhidra"):
+        if not project_dir:
+            return "[error] --project required with --backend ghidra"
+        from retools.pyghidra_backend import decompile as ghidra_decompile
+        ghidra_dir = str(Path(project_dir) / "ghidra")
+        return ghidra_decompile(ghidra_dir, binary, va)
+
+    if backend == "auto" and project_dir:
+        from retools.pyghidra_backend import is_analyzed, decompile as ghidra_decompile
+        bin_name = Path(binary).stem
+        ghidra_dir = str(Path(project_dir) / "ghidra")
+        if is_analyzed(ghidra_dir, bin_name):
+            result = ghidra_decompile(ghidra_dir, binary, va)
+            if not result.startswith("[error]"):
+                return result
+            # pyghidra error in auto mode -- fall through to r2ghidra
+    # -- end pyghidra routing (fall through to r2ghidra) --
+
     r2_bin = _find_r2_bin()
     if r2_bin is None:
         raise FileNotFoundError(
@@ -183,7 +208,7 @@ def main() -> None:
     p.add_argument("va", help="Function virtual address in hex (e.g. 0x401000)")
     p.add_argument(
         "-b", "--backend",
-        choices=["auto", *_BACKEND_CMDS],
+        choices=["auto", "ghidra", "pyhidra", *_BACKEND_CMDS],
         default="auto",
         help="Decompiler backend (default: auto – tries pdg then pdc)",
     )
@@ -197,6 +222,11 @@ def main() -> None:
         help="Knowledge base: inline types string, '-' for stdin, "
              "or path to .h file with structs/functions/globals",
     )
+    p.add_argument(
+        "-p", "--project",
+        help="Project directory (e.g. patches/MyGame). "
+             "Enables pyghidra backend when Ghidra project exists at <project>/ghidra/",
+    )
     args = p.parse_args()
     if not args.types:
         print("hint: use --types kb.h to load a knowledge base for richer output", file=sys.stderr)
@@ -204,7 +234,7 @@ def main() -> None:
           file=sys.stderr)
     print(decompile(args.binary, int(args.va, 16),
                     backend=args.backend, full_analysis=args.full_analysis,
-                    types=args.types))
+                    types=args.types, project_dir=args.project))
 
 
 if __name__ == "__main__":

--- a/retools/pyghidra_backend.py
+++ b/retools/pyghidra_backend.py
@@ -1,0 +1,238 @@
+"""Pyghidra (headless Ghidra) decompiler backend.
+
+Provides one-time analysis of PE binaries and on-demand decompilation
+using Ghidra's DecompInterface via the pyghidra bridge.
+"""
+
+import argparse
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# is_analyzed
+# ---------------------------------------------------------------------------
+
+def is_analyzed(project_dir: str, binary_name: str) -> bool:
+    """Check whether a Ghidra project with completed analysis exists.
+
+    Args:
+        project_dir: Path to the directory containing the .gpr and .rep.
+        binary_name: Original binary filename (e.g. ``game.exe``).
+
+    Returns:
+        True if a .gpr file and a non-empty .rep directory exist.
+    """
+    base = Path(project_dir)
+    stem = Path(binary_name).stem
+    # pyghidra.open_program() nests the project: project_dir/stem/stem.gpr
+    nested = base / stem
+    gpr = nested / f"{stem}.gpr"
+    rep = nested / f"{stem}.rep"
+    if not gpr.exists():
+        return False
+    if not rep.is_dir():
+        return False
+    if not any(rep.iterdir()):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# _import_pyghidra
+# ---------------------------------------------------------------------------
+
+_HERE = Path(__file__).resolve().parent
+_TOOLS = _HERE.parent / "tools"
+
+
+def _ensure_java_env():
+    """Set JAVA_HOME and PATH from portable JDK in tools/ if needed."""
+    if os.environ.get("JAVA_HOME") or shutil.which("java"):
+        return
+    for d in sorted(_TOOLS.glob("jdk-*"), reverse=True):
+        java_bin = d / "bin" / "java.exe"
+        if not java_bin.exists():
+            java_bin = d / "bin" / "java"
+        if java_bin.exists():
+            os.environ["JAVA_HOME"] = str(d)
+            os.environ["PATH"] = str(d / "bin") + os.pathsep + os.environ.get("PATH", "")
+            return
+
+
+def _ensure_ghidra_env():
+    """Set GHIDRA_INSTALL_DIR from tools/ if not already set."""
+    if os.environ.get("GHIDRA_INSTALL_DIR"):
+        return
+    for d in sorted(_TOOLS.glob("ghidra_*"), reverse=True):
+        if d.is_dir() and (d / "ghidraRun.bat").exists():
+            os.environ["GHIDRA_INSTALL_DIR"] = str(d)
+            return
+
+
+def _import_pyghidra():
+    """Lazily import pyghidra, returning None if not installed."""
+    _ensure_java_env()
+    _ensure_ghidra_env()
+    try:
+        import pyghidra
+        return pyghidra
+    except ImportError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# analyze
+# ---------------------------------------------------------------------------
+
+def analyze(binary: str, project_dir: str) -> str:
+    """Run Ghidra auto-analysis on a binary and save the project.
+
+    Args:
+        binary: Path to the PE binary to analyze.
+        project_dir: Directory to store the Ghidra project files.
+
+    Returns:
+        Summary string on success, or ``[error] ...`` on failure.
+    """
+    pyghidra = _import_pyghidra()
+    if pyghidra is None:
+        return "[error] pyghidra is not installed"
+
+    if not os.environ.get("GHIDRA_INSTALL_DIR"):
+        return "[error] GHIDRA_INSTALL_DIR environment variable not set"
+
+    binary_path = Path(binary)
+    proj_dir = Path(project_dir)
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    project_name = binary_path.stem
+
+    pyghidra.start()
+
+    t0 = time.time()
+    with pyghidra.open_program(
+        binary,
+        project_location=str(proj_dir),
+        project_name=project_name,
+        analyze=True,
+    ):
+        elapsed = time.time() - t0
+
+    return f"Analysis complete: {binary_path.name} ({elapsed:.1f}s), project saved to {proj_dir}"
+
+
+# ---------------------------------------------------------------------------
+# decompile
+# ---------------------------------------------------------------------------
+
+def decompile(project_dir: str, binary: str, va: int) -> str:
+    """Decompile a function at the given virtual address.
+
+    Opens a previously-analyzed Ghidra project and uses DecompInterface
+    to produce C output for the function containing ``va``.
+
+    Args:
+        project_dir: Path to the Ghidra project directory.
+        binary: Path to the original PE binary.
+        va: Virtual address inside the target function.
+
+    Returns:
+        Decompiled C string, or ``[error] ...`` on failure.
+    """
+    binary_path = Path(binary)
+    binary_name = binary_path.name
+
+    if not is_analyzed(project_dir, binary_name):
+        return f"[error] no analyzed project for {binary_name} in {project_dir}"
+
+    pyghidra = _import_pyghidra()
+    if pyghidra is None:
+        return "[error] pyghidra is not installed"
+
+    if not os.environ.get("GHIDRA_INSTALL_DIR"):
+        return "[error] GHIDRA_INSTALL_DIR environment variable not set"
+
+    project_name = binary_path.stem
+
+    pyghidra.start()
+
+    with pyghidra.open_program(
+        binary,
+        project_location=str(project_dir),
+        project_name=project_name,
+        analyze=False,
+    ) as flat_api:
+        program = flat_api.getCurrentProgram()
+        from ghidra.app.decompiler import DecompInterface, DecompileOptions
+        from ghidra.util.task import ConsoleTaskMonitor
+
+        ifc = DecompInterface()
+        ifc.setOptions(DecompileOptions())
+        ifc.openProgram(program)
+
+        addr = program.getAddressFactory().getDefaultAddressSpace().getAddress(va)
+        func = program.getListing().getFunctionContaining(addr)
+        if func is None:
+            return f"[error] no function found at 0x{va:X}"
+
+        monitor = ConsoleTaskMonitor()
+        result = ifc.decompileFunction(func, 60, monitor)
+        return result.getDecompiledFunction().getC()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    """CLI entry point with analyze, decompile, and status subcommands."""
+    parser = argparse.ArgumentParser(
+        prog="pyghidra_backend",
+        description="Pyghidra headless Ghidra backend",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # --- analyze ---
+    p_analyze = sub.add_parser("analyze", help="Run Ghidra auto-analysis on a binary")
+    p_analyze.add_argument("binary", help="Path to PE binary")
+    p_analyze.add_argument("--project", required=True, help="Project directory")
+
+    # --- decompile ---
+    p_decompile = sub.add_parser("decompile", help="Decompile a function")
+    p_decompile.add_argument("binary", help="Path to PE binary")
+    p_decompile.add_argument("va", help="Virtual address (hex)")
+    p_decompile.add_argument("--project", required=True, help="Project directory")
+
+    # --- status ---
+    p_status = sub.add_parser("status", help="Check analysis status")
+    p_status.add_argument("binary", help="Path to PE binary")
+    p_status.add_argument("--project", required=True, help="Project directory")
+
+    args = parser.parse_args()
+    ghidra_dir = str(Path(args.project) / "ghidra")
+    binary_name = Path(args.binary).name
+
+    if args.command == "status":
+        if is_analyzed(ghidra_dir, binary_name):
+            print(f"Analyzed: {binary_name}")
+        else:
+            print(f"Not analyzed: {binary_name}")
+        raise SystemExit(0)
+
+    if args.command == "analyze":
+        result = analyze(args.binary, ghidra_dir)
+        print(result)
+        raise SystemExit(0)
+
+    if args.command == "decompile":
+        va = int(args.va, 16) if args.va.startswith("0x") else int(args.va)
+        result = decompile(ghidra_dir, args.binary, va)
+        print(result)
+        raise SystemExit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -148,6 +148,23 @@ class TestPostprocess:
         assert "Init" in result
         assert "param_1->speed" in result
 
+    def test_renames_ghidra_FUN_prefix(self):
+        from context import postprocess
+        raw = "call FUN_00401000\nmov eax, FUN_00402000\n"
+        kb = {0x00401000: "ProcessInput", 0x00402000: "GetValue"}
+        result = postprocess(raw, kb)
+        assert "ProcessInput" in result
+        assert "GetValue" in result
+        assert "FUN_00401000" not in result
+
+    def test_renames_ghidra_FUN_16digit(self):
+        from context import postprocess
+        raw = "call FUN_0000000140001000\n"
+        kb = {0x0000000140001000: "WideFunc"}
+        result = postprocess(raw, kb)
+        assert "WideFunc" in result
+        assert "FUN_0000000140001000" not in result
+
 
 # ---------------------------------------------------------------------------
 # assemble

--- a/tests/test_decompiler.py
+++ b/tests/test_decompiler.py
@@ -1,0 +1,53 @@
+"""Tests for decompiler.py backend routing logic."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "retools"))
+
+
+class TestBackendRouting:
+    def test_auto_no_project_uses_r2(self):
+        """--backend auto without --project should use r2ghidra."""
+        from decompiler import decompile
+        with patch("decompiler._find_r2_bin", return_value=None):
+            with pytest.raises(FileNotFoundError, match="radare2 not found"):
+                decompile("fake.exe", 0x401000, backend="auto")
+
+    def test_auto_with_project_no_ghidra_falls_through(self, tmp_path):
+        """--backend auto with --project but no Ghidra project falls through to r2."""
+        mock_backend = MagicMock()
+        mock_backend.is_analyzed.return_value = False
+
+        with patch.dict(sys.modules, {"retools.pyghidra_backend": mock_backend}):
+            from importlib import reload
+            import decompiler
+            reload(decompiler)
+            with patch("decompiler._find_r2_bin", return_value=None):
+                with pytest.raises(FileNotFoundError, match="radare2 not found"):
+                    decompiler.decompile("fake.exe", 0x401000, backend="auto", project_dir=str(tmp_path))
+
+    def test_ghidra_backend_without_project_errors(self):
+        """--backend ghidra without --project returns error."""
+        from decompiler import decompile
+        result = decompile("fake.exe", 0x401000, backend="ghidra")
+        assert "[error]" in result
+        assert "--project required" in result
+
+    def test_ghidra_backend_routes_to_pyghidra(self, tmp_path):
+        """--backend ghidra with --project routes to pyghidra_backend."""
+        mock_backend = MagicMock()
+        mock_backend.decompile.return_value = "void func() {}"
+        mock_backend.is_analyzed.return_value = True
+
+        with patch.dict(sys.modules, {"retools.pyghidra_backend": mock_backend}):
+            from importlib import reload
+            import decompiler
+            reload(decompiler)
+            result = decompiler.decompile("fake.exe", 0x401000, backend="ghidra", project_dir=str(tmp_path))
+
+        mock_backend.decompile.assert_called_once()
+        assert result == "void func() {}"

--- a/tests/test_pyghidra_backend.py
+++ b/tests/test_pyghidra_backend.py
@@ -1,0 +1,324 @@
+"""Tests for retools/pyghidra_backend.py -- pyghidra headless Ghidra backend."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "retools"))
+
+
+# ---------------------------------------------------------------------------
+# is_analyzed
+# ---------------------------------------------------------------------------
+
+class TestIsAnalyzed:
+    def test_missing_dir(self, tmp_path):
+        from pyghidra_backend import is_analyzed
+        assert is_analyzed(str(tmp_path / "nonexistent"), "test.exe") is False
+
+    def test_missing_gpr(self, tmp_path):
+        from pyghidra_backend import is_analyzed
+        project_dir = tmp_path / "ghidra"
+        project_dir.mkdir()
+        assert is_analyzed(str(project_dir), "test.exe") is False
+
+    def test_empty_rep(self, tmp_path):
+        from pyghidra_backend import is_analyzed
+        project_dir = tmp_path / "ghidra"
+        project_dir.mkdir()
+        (project_dir / "test.gpr").write_text("")
+        (project_dir / "test.rep").mkdir()
+        assert is_analyzed(str(project_dir), "test.exe") is False
+
+    def test_valid_project(self, tmp_path):
+        from pyghidra_backend import is_analyzed
+        project_dir = tmp_path / "ghidra"
+        # pyghidra nests: project_dir/stem/stem.gpr
+        nested = project_dir / "test"
+        nested.mkdir(parents=True)
+        (nested / "test.gpr").write_text("project")
+        rep = nested / "test.rep"
+        rep.mkdir()
+        (rep / "data").write_text("data")
+        assert is_analyzed(str(project_dir), "test.exe") is True
+
+
+# ---------------------------------------------------------------------------
+# analyze
+# ---------------------------------------------------------------------------
+
+class TestAnalyze:
+    def test_calls_start_and_open_program(self, tmp_path, monkeypatch):
+        from pyghidra_backend import analyze
+        monkeypatch.setenv("GHIDRA_INSTALL_DIR", str(tmp_path))
+
+        mock_pyghidra = MagicMock()
+        mock_ctx = MagicMock()
+        mock_pyghidra.open_program.return_value.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_pyghidra.open_program.return_value.__exit__ = MagicMock(return_value=False)
+        monkeypatch.setitem(sys.modules, "pyghidra", mock_pyghidra)
+
+        binary = tmp_path / "test.exe"
+        binary.write_bytes(b"MZ" + b"\x00" * 100)
+        result = analyze(str(binary), str(tmp_path / "ghidra"))
+
+        mock_pyghidra.start.assert_called_once()
+        mock_pyghidra.open_program.assert_called_once()
+        assert "[error]" not in result
+
+    def test_creates_project_dir(self, tmp_path, monkeypatch):
+        from pyghidra_backend import analyze
+        monkeypatch.setenv("GHIDRA_INSTALL_DIR", str(tmp_path))
+
+        mock_pyghidra = MagicMock()
+        mock_ctx = MagicMock()
+        mock_pyghidra.open_program.return_value.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_pyghidra.open_program.return_value.__exit__ = MagicMock(return_value=False)
+        monkeypatch.setitem(sys.modules, "pyghidra", mock_pyghidra)
+
+        binary = tmp_path / "test.exe"
+        binary.write_bytes(b"MZ" + b"\x00" * 100)
+        project_dir = tmp_path / "ghidra" / "sub"
+        result = analyze(str(binary), str(project_dir))
+
+        assert project_dir.exists()
+
+    def test_error_no_ghidra_install_dir(self, tmp_path, monkeypatch):
+        from pyghidra_backend import analyze
+        monkeypatch.delenv("GHIDRA_INSTALL_DIR", raising=False)
+        # Patch _ensure_ghidra_env to not auto-detect from tools/
+        monkeypatch.setattr("pyghidra_backend._ensure_ghidra_env", lambda: None)
+
+        mock_pyghidra = MagicMock()
+        monkeypatch.setitem(sys.modules, "pyghidra", mock_pyghidra)
+
+        binary = tmp_path / "test.exe"
+        binary.write_bytes(b"MZ" + b"\x00" * 100)
+        result = analyze(str(binary), str(tmp_path / "ghidra"))
+
+        assert result.startswith("[error]")
+
+    def test_error_pyghidra_missing(self, tmp_path, monkeypatch):
+        from pyghidra_backend import analyze
+        monkeypatch.setenv("GHIDRA_INSTALL_DIR", str(tmp_path))
+        monkeypatch.delitem(sys.modules, "pyghidra", raising=False)
+
+        with patch("pyghidra_backend._import_pyghidra", return_value=None):
+            binary = tmp_path / "test.exe"
+            binary.write_bytes(b"MZ" + b"\x00" * 100)
+            result = analyze(str(binary), str(tmp_path / "ghidra"))
+
+        assert result.startswith("[error]")
+
+
+# ---------------------------------------------------------------------------
+# decompile
+# ---------------------------------------------------------------------------
+
+def _setup_ghidra_project(tmp_path):
+    """Create a fake valid Ghidra project on disk for decompile() checks."""
+    project_dir = tmp_path / "ghidra"
+    # pyghidra nests: project_dir/stem/stem.gpr
+    nested = project_dir / "test"
+    nested.mkdir(parents=True)
+    (nested / "test.gpr").write_text("project")
+    rep = nested / "test.rep"
+    rep.mkdir()
+    (rep / "data").write_text("data")
+    return project_dir
+
+
+def _mock_java_modules(monkeypatch):
+    """Inject mock Java modules (ghidra.app.decompiler, ghidra.util.task)."""
+    mock_decomp_mod = MagicMock()
+    mock_task_mod = MagicMock()
+
+    mock_ifc = MagicMock()
+    mock_decomp_mod.DecompInterface.return_value = mock_ifc
+
+    mock_monitor = MagicMock()
+    mock_task_mod.ConsoleTaskMonitor.return_value = mock_monitor
+
+    monkeypatch.setitem(sys.modules, "ghidra", MagicMock())
+    monkeypatch.setitem(sys.modules, "ghidra.app", MagicMock())
+    monkeypatch.setitem(sys.modules, "ghidra.app.decompiler", mock_decomp_mod)
+    monkeypatch.setitem(sys.modules, "ghidra.util", MagicMock())
+    monkeypatch.setitem(sys.modules, "ghidra.util.task", mock_task_mod)
+
+    return mock_ifc, mock_monitor
+
+
+class TestDecompile:
+    def test_returns_c_output(self, tmp_path, monkeypatch):
+        from pyghidra_backend import decompile
+        monkeypatch.setenv("GHIDRA_INSTALL_DIR", str(tmp_path))
+
+        project_dir = _setup_ghidra_project(tmp_path)
+        binary = tmp_path / "test.exe"
+        binary.write_bytes(b"MZ" + b"\x00" * 100)
+
+        mock_pyghidra = MagicMock()
+        mock_flat_api = MagicMock()
+        mock_program = MagicMock()
+        mock_pyghidra.open_program.return_value.__enter__ = MagicMock(return_value=mock_flat_api)
+        mock_pyghidra.open_program.return_value.__exit__ = MagicMock(return_value=False)
+        mock_flat_api.getCurrentProgram.return_value = mock_program
+        monkeypatch.setitem(sys.modules, "pyghidra", mock_pyghidra)
+
+        mock_ifc, mock_monitor = _mock_java_modules(monkeypatch)
+
+        # Mock the listing / function lookup
+        mock_func = MagicMock()
+        mock_listing = MagicMock()
+        mock_program.getListing.return_value = mock_listing
+        mock_listing.getFunctionContaining.return_value = mock_func
+
+        # Mock decompile result
+        mock_result = MagicMock()
+        mock_result.getDecompiledFunction.return_value.getC.return_value = (
+            "int foo(void) {\n  return 42;\n}"
+        )
+        mock_ifc.decompileFunction.return_value = mock_result
+
+        result = decompile(str(project_dir), str(binary), 0x401000)
+        assert "int foo(void)" in result
+        assert "[error]" not in result
+
+    def test_error_no_function(self, tmp_path, monkeypatch):
+        from pyghidra_backend import decompile
+        monkeypatch.setenv("GHIDRA_INSTALL_DIR", str(tmp_path))
+
+        project_dir = _setup_ghidra_project(tmp_path)
+        binary = tmp_path / "test.exe"
+        binary.write_bytes(b"MZ" + b"\x00" * 100)
+
+        mock_pyghidra = MagicMock()
+        mock_flat_api = MagicMock()
+        mock_program = MagicMock()
+        mock_pyghidra.open_program.return_value.__enter__ = MagicMock(return_value=mock_flat_api)
+        mock_pyghidra.open_program.return_value.__exit__ = MagicMock(return_value=False)
+        mock_flat_api.getCurrentProgram.return_value = mock_program
+        monkeypatch.setitem(sys.modules, "pyghidra", mock_pyghidra)
+
+        mock_ifc, mock_monitor = _mock_java_modules(monkeypatch)
+
+        # No function at this address
+        mock_listing = MagicMock()
+        mock_program.getListing.return_value = mock_listing
+        mock_listing.getFunctionContaining.return_value = None
+
+        result = decompile(str(project_dir), str(binary), 0x401000)
+        assert result.startswith("[error]")
+
+
+# ---------------------------------------------------------------------------
+# CLI (main)
+# ---------------------------------------------------------------------------
+
+class TestCLI:
+    def test_status_not_analyzed(self, tmp_path, capsys):
+        from pyghidra_backend import main
+        with pytest.raises(SystemExit, match="0"):
+            sys.argv = [
+                "pyghidra_backend",
+                "status",
+                str(tmp_path / "test.exe"),
+                "--project", "TestProj",
+            ]
+            main()
+        captured = capsys.readouterr()
+        assert "not analyzed" in captured.out.lower()
+
+    def test_status_analyzed(self, tmp_path, capsys):
+        from pyghidra_backend import main
+        # Set up a valid project under patches/TestProj/ghidra/test/
+        nested = tmp_path / "patches" / "TestProj" / "ghidra" / "test"
+        nested.mkdir(parents=True)
+        (nested / "test.gpr").write_text("project")
+        rep = nested / "test.rep"
+        rep.mkdir()
+        (rep / "data").write_text("data")
+
+        binary = tmp_path / "test.exe"
+        binary.write_bytes(b"MZ" + b"\x00" * 100)
+
+        with pytest.raises(SystemExit, match="0"):
+            sys.argv = [
+                "pyghidra_backend",
+                "status",
+                str(binary),
+                "--project", str(tmp_path / "patches" / "TestProj"),
+            ]
+            main()
+        captured = capsys.readouterr()
+        assert "analyzed" in captured.out.lower()
+
+    def test_analyze_subcommand(self, tmp_path, capsys, monkeypatch):
+        from pyghidra_backend import main
+        monkeypatch.setenv("GHIDRA_INSTALL_DIR", str(tmp_path))
+
+        mock_pyghidra = MagicMock()
+        mock_ctx = MagicMock()
+        mock_pyghidra.open_program.return_value.__enter__ = MagicMock(return_value=mock_ctx)
+        mock_pyghidra.open_program.return_value.__exit__ = MagicMock(return_value=False)
+        monkeypatch.setitem(sys.modules, "pyghidra", mock_pyghidra)
+
+        binary = tmp_path / "test.exe"
+        binary.write_bytes(b"MZ" + b"\x00" * 100)
+
+        with pytest.raises(SystemExit, match="0"):
+            sys.argv = [
+                "pyghidra_backend",
+                "analyze",
+                str(binary),
+                "--project", str(tmp_path / "patches" / "TestProj"),
+            ]
+            main()
+        captured = capsys.readouterr()
+        assert "analysis complete" in captured.out.lower()
+
+    def test_decompile_subcommand(self, tmp_path, capsys, monkeypatch):
+        from pyghidra_backend import main
+        monkeypatch.setenv("GHIDRA_INSTALL_DIR", str(tmp_path))
+
+        # Set up a valid project (nested: ghidra/test/test.gpr)
+        nested = tmp_path / "patches" / "TestProj" / "ghidra" / "test"
+        nested.mkdir(parents=True)
+        (nested / "test.gpr").write_text("project")
+        rep = nested / "test.rep"
+        rep.mkdir()
+        (rep / "data").write_text("data")
+
+        binary = tmp_path / "test.exe"
+        binary.write_bytes(b"MZ" + b"\x00" * 100)
+
+        mock_pyghidra = MagicMock()
+        mock_flat_api = MagicMock()
+        mock_program = MagicMock()
+        mock_pyghidra.open_program.return_value.__enter__ = MagicMock(return_value=mock_flat_api)
+        mock_pyghidra.open_program.return_value.__exit__ = MagicMock(return_value=False)
+        mock_flat_api.getCurrentProgram.return_value = mock_program
+        monkeypatch.setitem(sys.modules, "pyghidra", mock_pyghidra)
+
+        mock_ifc, _ = _mock_java_modules(monkeypatch)
+        mock_func = MagicMock()
+        mock_listing = MagicMock()
+        mock_program.getListing.return_value = mock_listing
+        mock_listing.getFunctionContaining.return_value = mock_func
+        mock_result = MagicMock()
+        mock_result.getDecompiledFunction.return_value.getC.return_value = "void bar(void) {}"
+        mock_ifc.decompileFunction.return_value = mock_result
+
+        with pytest.raises(SystemExit, match="0"):
+            sys.argv = [
+                "pyghidra_backend",
+                "decompile",
+                str(binary),
+                "0x401000",
+                "--project", str(tmp_path / "patches" / "TestProj"),
+            ]
+            main()
+        captured = capsys.readouterr()
+        assert "void bar(void)" in captured.out

--- a/verify_install.py
+++ b/verify_install.py
@@ -1,15 +1,34 @@
-"""Smoke-test that all RE toolkit dependencies are installed and usable."""
+"""Smoke-test that all RE toolkit dependencies are installed and usable.
+
+Usage:
+    python verify_install.py              # check only
+    python verify_install.py --setup      # check + auto-install missing optional deps (Ghidra, JDK, pyghidra)
+"""
 
 import importlib
+import io
+import os
+import shutil
 import struct
 import subprocess
 import sys
+import zipfile
 from pathlib import Path
+from urllib.request import urlopen
 
 ROOT = Path(__file__).resolve().parent
+TOOLS_DIR = ROOT / "tools"
 R2_DIR = next(ROOT.glob("tools/radare2-*/bin"), None)
-PASS, FAIL, WARN = "PASS", "FAIL", "WARN"
+PASS, FAIL, WARN, SKIP = "PASS", "FAIL", "WARN", "SKIP"
 results: list[tuple[str, str, str]] = []
+
+GHIDRA_VERSION = "11.4.3"
+GHIDRA_DATE = "20251203"
+GHIDRA_ZIP = f"ghidra_{GHIDRA_VERSION}_PUBLIC_{GHIDRA_DATE}.zip"
+GHIDRA_URL = f"https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_{GHIDRA_VERSION}_build/{GHIDRA_ZIP}"
+GHIDRA_DIR_NAME = f"ghidra_{GHIDRA_VERSION}_PUBLIC"
+JDK_VERSION = "21"
+JDK_ADOPTIUM_URL = "https://api.adoptium.net/v3/binary/latest/21/ga/windows/x64/jdk/hotspot/normal/eclipse"
 
 
 def record(name: str, status: str, detail: str = ""):
@@ -95,6 +114,59 @@ def check_sigdb():
                "signatures.db missing or empty -- run: python retools/sigdb.py pull")
 
 
+def check_java() -> bool:
+    """Check for JDK 21+. Returns True if found."""
+    try:
+        out = subprocess.check_output(
+            ["java", "-version"], stderr=subprocess.STDOUT, timeout=10
+        ).decode(errors="replace")
+        first = out.strip().split("\n")[0]
+        record("java", PASS, first)
+        return True
+    except FileNotFoundError:
+        record("java", WARN, "java not found -- required for pyghidra/Ghidra backend")
+        return False
+    except Exception as e:
+        record("java", WARN, f"java check failed: {e}")
+        return False
+
+
+def _find_ghidra_dir() -> Path | None:
+    """Find Ghidra installation: env var first, then tools/ directory."""
+    env = os.environ.get("GHIDRA_INSTALL_DIR", "")
+    if env and Path(env).is_dir():
+        return Path(env)
+    candidate = TOOLS_DIR / GHIDRA_DIR_NAME
+    if candidate.is_dir():
+        return candidate
+    for d in sorted(TOOLS_DIR.glob("ghidra_*"), reverse=True):
+        if d.is_dir() and (d / "ghidraRun.bat").exists():
+            return d
+    return None
+
+
+def check_ghidra() -> bool:
+    """Check for Ghidra installation. Returns True if found."""
+    ghidra = _find_ghidra_dir()
+    if ghidra:
+        record("ghidra-install", PASS, str(ghidra))
+        return True
+    record("ghidra-install", WARN,
+           "Ghidra not found in tools/ or GHIDRA_INSTALL_DIR -- "
+           "run: python verify_install.py --setup")
+    return False
+
+
+def check_pyghidra():
+    try:
+        import pyghidra
+        ver = getattr(pyghidra, "__version__", "?")
+        record("pip:pyghidra", PASS, f"v{ver}")
+    except ImportError:
+        record("pip:pyghidra", WARN,
+               "pyghidra not installed -- run: python verify_install.py --setup")
+
+
 def check_retools_import():
     modules = [
         "retools.common", "retools.decompiler", "retools.disasm",
@@ -118,21 +190,186 @@ def check_retools_import():
             record("retools", FAIL, msg)
 
 
+def _download(url: str, desc: str) -> bytes:
+    """Download a URL with progress reporting."""
+    from urllib.request import Request
+    print(f"  Downloading {desc}...")
+    req = Request(url, headers={"User-Agent": "vibe-re-toolkit/1.0"})
+    resp = urlopen(req)
+    total = int(resp.headers.get("Content-Length", 0))
+    data = bytearray()
+    while True:
+        chunk = resp.read(1 << 20)  # 1MB chunks
+        if not chunk:
+            break
+        data.extend(chunk)
+        if total:
+            pct = len(data) * 100 // total
+            mb = len(data) / (1 << 20)
+            print(f"\r  {mb:.0f} MB / {total / (1 << 20):.0f} MB ({pct}%)", end="", flush=True)
+    print()
+    return bytes(data)
+
+
+def setup_jdk():
+    """Download and install Adoptium JDK 21 to tools/jdk-21."""
+    if shutil.which("java"):
+        try:
+            out = subprocess.check_output(
+                ["java", "-version"], stderr=subprocess.STDOUT, timeout=10
+            ).decode(errors="replace")
+            if f'"{JDK_VERSION}.' in out or f" {JDK_VERSION}." in out:
+                print(f"  JDK {JDK_VERSION} already installed (system)")
+                return True
+        except Exception:
+            pass
+
+    # Check if we already downloaded it
+    for d in TOOLS_DIR.glob(f"jdk-{JDK_VERSION}*"):
+        if (d / "bin" / "java.exe").exists():
+            print(f"  JDK already at {d}")
+            os.environ["JAVA_HOME"] = str(d)
+            os.environ["PATH"] = str(d / "bin") + os.pathsep + os.environ.get("PATH", "")
+            return True
+
+    print(f"\n  JDK {JDK_VERSION} not found. Downloading Adoptium Temurin JDK {JDK_VERSION}...")
+    try:
+        data = _download(JDK_ADOPTIUM_URL, f"JDK {JDK_VERSION}")
+        TOOLS_DIR.mkdir(parents=True, exist_ok=True)
+        zip_path = TOOLS_DIR / f"jdk-{JDK_VERSION}.zip"
+        zip_path.write_bytes(data)
+        with zipfile.ZipFile(zip_path) as zf:
+            zf.extractall(TOOLS_DIR)
+        zip_path.unlink()
+        jdk_dir = next(TOOLS_DIR.glob(f"jdk-{JDK_VERSION}*"), None)
+        if jdk_dir and (jdk_dir / "bin" / "java.exe").exists():
+            os.environ["JAVA_HOME"] = str(jdk_dir)
+            os.environ["PATH"] = str(jdk_dir / "bin") + os.pathsep + os.environ.get("PATH", "")
+            record("setup:jdk", PASS, f"Installed to {jdk_dir}")
+            return True
+        record("setup:jdk", FAIL, "Extraction succeeded but java.exe not found")
+        return False
+    except Exception as e:
+        record("setup:jdk", FAIL, f"Download failed: {e}")
+        return False
+
+
+def setup_ghidra():
+    """Download and extract Ghidra to tools/."""
+    existing = _find_ghidra_dir()
+    if existing:
+        print(f"  Ghidra already at {existing}")
+        os.environ["GHIDRA_INSTALL_DIR"] = str(existing)
+        return True
+
+    print(f"\n  Downloading Ghidra {GHIDRA_VERSION} (~435 MB)...")
+    try:
+        data = _download(GHIDRA_URL, f"Ghidra {GHIDRA_VERSION}")
+        TOOLS_DIR.mkdir(parents=True, exist_ok=True)
+        zip_path = TOOLS_DIR / GHIDRA_ZIP
+        zip_path.write_bytes(data)
+        print("  Extracting...")
+        with zipfile.ZipFile(zip_path) as zf:
+            zf.extractall(TOOLS_DIR)
+        zip_path.unlink()
+        ghidra_dir = TOOLS_DIR / GHIDRA_DIR_NAME
+        if ghidra_dir.is_dir():
+            os.environ["GHIDRA_INSTALL_DIR"] = str(ghidra_dir)
+            record("setup:ghidra", PASS, f"Installed to {ghidra_dir}")
+            return True
+        record("setup:ghidra", FAIL, "Extraction succeeded but directory not found")
+        return False
+    except Exception as e:
+        record("setup:ghidra", FAIL, f"Download failed: {e}")
+        return False
+
+
+def setup_pyghidra():
+    """Install pyghidra via pip."""
+    try:
+        import pyghidra
+        print(f"  pyghidra already installed (v{getattr(pyghidra, '__version__', '?')})")
+        return True
+    except ImportError:
+        pass
+
+    print("  Installing pyghidra...")
+    try:
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "pyghidra>=2.0.0,<4.0.0", "-q"],
+            timeout=120,
+        )
+        record("setup:pyghidra", PASS, "Installed via pip")
+        return True
+    except Exception as e:
+        record("setup:pyghidra", FAIL, f"pip install failed: {e}")
+        return False
+
+
+def run_setup():
+    """Auto-install optional pyghidra dependencies: JDK, Ghidra, pyghidra."""
+    print("=" * 60)
+    print("Pyghidra Setup (optional Ghidra decompiler backend)")
+    print("=" * 60)
+
+    if not setup_jdk():
+        print("\n  Cannot proceed without JDK. Install JDK 21+ manually.")
+        return
+
+    if not setup_ghidra():
+        print("\n  Cannot proceed without Ghidra. Download manually from ghidra-sre.org")
+        return
+
+    setup_pyghidra()
+
+    ghidra_dir = _find_ghidra_dir()
+    if ghidra_dir:
+        print(f"\n  Set GHIDRA_INSTALL_DIR={ghidra_dir}")
+        print("  Add to your shell profile for persistent use:")
+        print(f'    export GHIDRA_INSTALL_DIR="{ghidra_dir}"')
+
+    print()
+
+
 def main():
+    setup_mode = "--setup" in sys.argv
+
     print("RE Toolkit Install Verification\n")
     check_lfs()
     check_r2ghidra()
     check_python_deps()
+    check_java()
+    check_ghidra()
+    check_pyghidra()
     check_r2_runs()
     check_retools_import()
     check_sigdb()
 
     failures = sum(1 for _, s, _ in results if s == FAIL)
+    warns = sum(1 for _, s, _ in results if s == WARN)
     print()
+
     if failures:
         print(f"FAILED: {failures} check(s) did not pass.")
         print("Fix the above issues before using the toolkit.")
         sys.exit(1)
+
+    if warns and setup_mode:
+        ghidra_warns = any(
+            n in ("java", "ghidra-install", "pip:pyghidra")
+            for n, s, _ in results if s == WARN
+        )
+        if ghidra_warns:
+            run_setup()
+            # Re-check after setup
+            results.clear()
+            print("Re-checking after setup...\n")
+            check_java()
+            check_ghidra()
+            check_pyghidra()
+    elif warns:
+        print(f"ALL REQUIRED CHECKS PASSED ({warns} optional warning(s)).")
+        print("Run 'python verify_install.py --setup' to auto-install optional Ghidra backend.")
     else:
         print("ALL CHECKS PASSED.")
 


### PR DESCRIPTION
pyghidra resolves library calls (_memcpy_s, _memset) that r2ghidra misses, finds larger function scopes, and propagates types better. r2ghidra handles __thiscall on small functions better and has no JVM startup cost. Running both  
  in parallel and merging findings produces the most complete analysis.
  
  - Add pyghidra (headless Ghidra) as an alternative decompiler backend alongside r2ghidra
  - --backend auto prefers pyghidra when a Ghidra project exists, falls through to r2ghidra seamlessly
  - verify_install.py --setup auto-downloads JDK 21 + Ghidra 11.4.3 + pyghidra (~600MB, one-time)
  - Auto-detects portable JDK/Ghidra from tools/, zero env vars needed
  - Dual-backend deep analysis pattern: spawn parallel agents with different backends for exploratory RE tasks
  - All IDE configs synced (Claude, Cursor, Kiro, GitHub Copilot)

  Benchmark (mb_warband.exe, midtown.exe)

  Test plan

  - 39 unit tests pass (14 pyghidra_backend, 4 decompiler routing, 2 context regex, 19 existing)
  - verify_install.py shows all green (WARN not FAIL when Ghidra absent)
  - verify_install.py --setup downloads and installs on clean machine
  - Benchmarked against two real game binaries with both backends
  - CODE_REVIEW.md checklist passed (general purpose, no game data, no duplication, IDEs synced)